### PR TITLE
Specify mapping for regional missense constraint data

### DIFF
--- a/packages/api/src/schema/types/regionalConstraint.js
+++ b/packages/api/src/schema/types/regionalConstraint.js
@@ -13,7 +13,7 @@ export const regionalConstraintRegion = new GraphQLObjectType({
   fields: () => ({
     transcript: { type: GraphQLString },
     gene: { type: GraphQLString },
-    chr: { type: GraphQLFloat },
+    chr: { type: GraphQLString },
     amino_acids: { type: GraphQLString },
     genomic_start: { type: GraphQLInt },
     genomic_end: { type: GraphQLInt },

--- a/projects/gnomad/data/export_regional_constraint_gene_stats.js
+++ b/projects/gnomad/data/export_regional_constraint_gene_stats.js
@@ -1,6 +1,6 @@
 import { loadCsvToElastic } from '@broad/api/utilities/elasticsearch'
 
-const filePath = '../../@broad/redux-fordist_constraint_official_fullgene_cleaned_missense_metrics_nosynoutliers.txt'
+const filePath = '../../../resources/fordist_constraint_official_fullgene_cleaned_missense_metrics_nosynoutliers.txt'
 
 const headers = [
   'transcript',

--- a/projects/gnomad/data/export_regional_constraint_regional_missense.js
+++ b/projects/gnomad/data/export_regional_constraint_regional_missense.js
@@ -1,6 +1,6 @@
 import { loadCsvToElastic } from '@broad/api/utilities/elasticsearch'
 
-const filePath = '../../@broad/redux-fordist_constraint_official_regional_missense_cleaned_metrics_nosynoutliers.txt'
+const filePath = '../../../resources/fordist_constraint_official_regional_missense_cleaned_metrics_nosynoutliers.txt'
 
 const config = {
   address: '23.236.50.46:9200',

--- a/projects/gnomad/data/export_regional_constraint_regional_missense.js
+++ b/projects/gnomad/data/export_regional_constraint_regional_missense.js
@@ -1,14 +1,16 @@
 import { loadCsvToElastic } from '@broad/api/utilities/elasticsearch'
+import regionalMissenseMapping from './regional_missense_mapping.json'
 
 const filePath = '../../../resources/fordist_constraint_official_regional_missense_cleaned_metrics_nosynoutliers.txt'
 
 const config = {
   address: '23.236.50.46:9200',
-  dropPreviousIndex: false,
+  dropPreviousIndex: true,
   filePath,
   delimiter: '\t',
   indexName: 'regional_missense',
   typeName: 'region',
+  mapping: regionalMissenseMapping,
 }
 
 loadCsvToElastic(config)

--- a/projects/gnomad/data/regional_missense_mapping.json
+++ b/projects/gnomad/data/regional_missense_mapping.json
@@ -1,0 +1,37 @@
+{
+  "properties": {
+    "amino_acids": {
+      "type": "text"
+    },
+    "chisq_diff_null": {
+      "type": "float"
+    },
+    "chr": {
+      "type": "text"
+    },
+    "exp_mis": {
+      "type": "float"
+    },
+    "gene": {
+      "type": "text"
+    },
+    "genomic_end": {
+      "type": "long"
+    },
+    "genomic_start": {
+      "type": "long"
+    },
+    "obs_exp": {
+      "type": "float"
+    },
+    "obs_mis": {
+      "type": "long"
+    },
+    "region_name": {
+      "type": "text"
+    },
+    "transcript": {
+      "type": "text"
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/macarthur-lab/gnomad_browser/issues/108

Currently, when uploading regional missense constraint data, ES automatically sets the mapping for `regional_missense/region`. Since the records in the data file are ordered by chromosome (1-22, X), ES maps the `chr` field to a numeric type (`long`).

However, not all records have a numeric value for `chr`. Some genes (such as CDKL5 which was reported in the issue) have a value of 'X' for the `chr` field. With `chr` mapped to a `long` type, records for chromosome 'X' do not appear in query results.

This change explicitly sets the mapping for `regional_missense/region` instead of allowing ES to auto-detect it. With `chr` set to a text field, query results include records for chromosome 'X'.
