### PR TITLE
Change icon on transcript pop out button

### DIFF
--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -350,6 +350,7 @@ const Transcript = ({
     paddingBottom = 0  // eslint-disable-line
     expandTranscriptButton = (
       <TranscriptFlipOutButton
+        fanOutIsOpen={fanOutButtonOpen}
         strand={strand}
         onClick={fanOut}
       />

--- a/packages/track-transcript/src/transcriptFlipOutButton.js
+++ b/packages/track-transcript/src/transcriptFlipOutButton.js
@@ -10,11 +10,6 @@ const TranscriptFlipOutButtonContainer = styled.div`
   height: 100%;
   width: 100%;
   border: 1px blue #000;
-
-  i {
-    margin-right: 10px;
-    color: rgb(66, 66, 66);
-  }
 `
 
 const TranscriptFlipOutButton = styled.button`
@@ -34,7 +29,7 @@ const TranscriptFlipOutButton = styled.button`
   }
 `
 
-const TranscriptFlipOut = ({ onClick, strand }) => {
+const TranscriptFlipOut = ({ fanOutIsOpen, onClick, strand }) => {
   let direction
   if (strand === '+') {
     direction = 'right'
@@ -43,25 +38,45 @@ const TranscriptFlipOut = ({ onClick, strand }) => {
   } else {
     direction = null
   }
+
+  const label = fanOutIsOpen
+    ? 'Hide alternate transcripts'
+    : 'Show alternate transcripts'
+
+  const icon = fanOutIsOpen
+    ? 'fa-caret-down'
+    : 'fa-caret-right'
+
   return (
     <TranscriptFlipOutButtonContainer>
       <TranscriptFlipOutButton
+        aria-label={label}
         onClick={onClick}
+        title={label}
       >
-        +
+        <i
+          aria-hidden
+          className={`fa ${icon}`}
+        />
       </TranscriptFlipOutButton>
       {direction && <i
         className={`fa fa-arrow-circle-${direction} fa-2x`}
         aria-hidden="true"
+        style={{
+          marginRight: '10px',
+          color: 'rgb(66, 66, 66)',
+        }}
       />}
     </TranscriptFlipOutButtonContainer>
   )
 }
 TranscriptFlipOut.propTypes = {
+  fanOutIsOpen: PropTypes.bool,
   onClick: PropTypes.func,
   strand: PropTypes.string,
 }
 TranscriptFlipOut.defaultProps = {
+  fanOutIsOpen: false,
   onClick: () => {},
   strand: null,
 }


### PR DESCRIPTION
Resolves #14 

Currently, the button to toggle transcripts has a "+" icon. This can be confusing since strand is also represented with a "+" or "-".

This changes the icon to a caret (facing down when transcripts are visible and right when transcripts are hidden).

## Before
<img width="1024" alt="screen shot 2018-04-27 at 3 16 22 pm" src="https://user-images.githubusercontent.com/1156625/39381284-9ae6cac8-4a2f-11e8-88f8-8932115f7c02.png">
<img width="873" alt="screen shot 2018-04-27 at 3 29 23 pm" src="https://user-images.githubusercontent.com/1156625/39381352-cee32010-4a2f-11e8-91a6-bce1f4da70b1.png">


## After
<img width="1027" alt="screen shot 2018-04-27 at 3 19 11 pm" src="https://user-images.githubusercontent.com/1156625/39381285-9af12f4a-4a2f-11e8-85bd-ecbb6aefba04.png">
<img width="869" alt="screen shot 2018-04-27 at 3 26 23 pm" src="https://user-images.githubusercontent.com/1156625/39381286-9b01f35c-4a2f-11e8-9831-7f147d3c26cd.png">

When the mouse cursor is hovered over the button, a tooltip is shown
<img width="1023" alt="screen shot 2018-04-27 at 3 17 29 pm" src="https://user-images.githubusercontent.com/1156625/39381287-9b0ddfdc-4a2f-11e8-8834-8f24cb4ba2ef.png">
<img width="868" alt="screen shot 2018-04-27 at 3 18 10 pm" src="https://user-images.githubusercontent.com/1156625/39381288-9b1732bc-4a2f-11e8-9813-1067dc57b239.png">
