### PR TITLE
Prevent controls in help footer from shrinking

### DIFF
--- a/packages/help/src/Help.js
+++ b/packages/help/src/Help.js
@@ -144,6 +144,7 @@ const HelpTopic = styled.div`
 const FooterContainer = styled.div`
   display: flex;
   flex-direction: row;
+  flex-shrink: 0;
   height: 50px;
   width: 100%;
   margin-top: 10px;


### PR DESCRIPTION
For help topics where the content is long and causes the help window to scroll, the controls at the bottom of the help window can get compressed.

For example, the "Gene constraint" topic
<img width="965" alt="screen shot 2018-04-27 at 4 37 01 pm" src="https://user-images.githubusercontent.com/1156625/39384737-d9c1adce-4a3b-11e8-927d-dede645acb6d.png">

## Before
<img width="556" alt="screen shot 2018-04-27 at 4 37 15 pm" src="https://user-images.githubusercontent.com/1156625/39384831-198450e2-4a3c-11e8-8b7f-5390c1a6d9e4.png">

## After
<img width="546" alt="screen shot 2018-04-27 at 4 40 44 pm" src="https://user-images.githubusercontent.com/1156625/39384832-19913ec4-4a3c-11e8-8468-48d8a6fe7031.png">

