### PR TITLE
Return offset value for positions outside an exon region

### DIFF
--- a/packages/utilities/src/coordinates/index.js
+++ b/packages/utilities/src/coordinates/index.js
@@ -154,16 +154,12 @@ export const calculateOffsetRegions = (
 )(regions)
 
 export const calculatePositionOffset = R.curry((regions, position) => {
-  let result = 0
-  for (let i = 0; i < regions.length; i++) {
-    if (position >= regions[i].start && position <= regions[i].stop) {
-      result = {
-        offsetPosition: position - regions[i].offset,
-        color: regions[i].color,
-      }
-    }
+  const lastRegionBeforePosition = R.findLast(region => region.start <= position)(regions)
+  const region = R.defaultTo(regions[0])(lastRegionBeforePosition)
+  return {
+    offsetPosition: position - region.offset,
+    color: region.color,
   }
-  return result
 })
 
 export const invertPositionOffset = R.curry((regions, xScale, scaledPosition) => {

--- a/projects/gnomad/src/GenePage/RegionViewer.js
+++ b/projects/gnomad/src/GenePage/RegionViewer.js
@@ -149,13 +149,13 @@ const GeneViewer = ({
               fill={'yellow'}
               stroke={'black'}
             /> */}
-            {regionalConstraintData.map((region, i) => {
+            {regionalConstraintData.map((region) => {
               const regionStart = strand === '+' ? region.genomic_start : region.genomic_end
               const regionStop = strand === '+' ? region.genomic_end : region.genomic_start
               const regionStartPos = positionOffset(regionStart).offsetPosition
               const regionStopPos = positionOffset(regionStop).offsetPosition
               return (
-                <g key={`${i}-region`}>
+                <g key={region.region_name}>
                   <RegionalConstraintRegion
                     x={xScale(regionStartPos)}
                     y={padding}


### PR DESCRIPTION
Resolves https://github.com/macarthur-lab/gnomad_browser/issues/108 (again)

Currently, `calculatePositionOffset` does not return an `offsetPosition` value for any position which does not fall within one of the exon regions. Some of the missense constraint regions have start/stop positions outside one of those regions, which results in the constraint region not being rendered.

## Before
<img width="985" alt="screen shot 2018-05-01 at 11 15 01 am" src="https://user-images.githubusercontent.com/1156625/39479078-33c3fd42-4d32-11e8-98ce-b48d4941ea72.png">

JS errors:
```
Error: <rect> attribute x: Expected length, "NaN".
Error: <rect> attribute width: Expected length, "NaN".
Error: <text> attribute x: Expected length, "NaN".
Error: <rect> attribute x: Expected length, "NaN".
Error: <rect> attribute width: Expected length, "NaN".
Error: <text> attribute x: Expected length, "NaN".
```

## After
<img width="984" alt="screen shot 2018-05-01 at 11 15 16 am" src="https://user-images.githubusercontent.com/1156625/39479090-39ebc574-4d32-11e8-8635-d1b279585ba5.png">
