### PR TITLE
Optimize GeneViewer rendering

### DIFF
--- a/projects/gnomad/src/GenePage/RegionViewer.js
+++ b/projects/gnomad/src/GenePage/RegionViewer.js
@@ -61,6 +61,11 @@ export const getCoverageConfig = (
   }
 }
 
+const RegionViewerWrapper = styled.div`
+  margin-left: 10px;
+  width: 100%;
+`
+
 const GeneViewer = ({
   gene,
   allVariants,
@@ -182,13 +187,6 @@ const GeneViewer = ({
       </RegionalConstraintTrackWrapper>
     )
   }
-
-  const RegionViewerWrapper = styled.div`
-    margin-left: 10px;
-    width: 100%;
-    padding-left: 0;
-    ${'' /* border: 5px solid orange; */}
-  `
 
   const RegionViewerSectionTitle = SectionTitle.extend`
     margin-left: 80px;


### PR DESCRIPTION
The component (RegionViewerWrapper) at the root of GeneViewer's element tree was defined in GeneViewer's render method. Thus, each render would have a different component at the root of the tree, leaving React unable to reconcile changes to GeneViewer and causing all children to be unmounted and recreated.