### PR TITLE
Update styles of regional constraint track

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,10 @@
     "no-confusing-arrow": 0,
     "space-before-function-paren": 0,
     "no-use-before-define": 0,
-    "no-unused-vars": ["error", { "varsIgnorePattern": "_" }],
+    "no-unused-vars": ["error", {
+      "ignoreRestSiblings": true,
+      "varsIgnorePattern": "_"
+    }],
     "import/prefer-default-export": 0,
     # "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.js", "**/*.spec.js", "**/*.example.js"]}],
     "import/no-extraneous-dependencies": 0,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -25,6 +25,7 @@
   "license": "ISC",
   "dependencies": {
     "compression": "^1.7.1",
+    "core-js": "^2.5.0",
     "cors": "^2.8.1",
     "elasticsearch": "^13.3.1",
     "express": "^4.14.0",

--- a/packages/track-regional-constraint/package.json
+++ b/packages/track-regional-constraint/package.json
@@ -7,6 +7,7 @@
     "lib"
   ],
   "dependencies": {
+    "@broad/help": "*",
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {

--- a/packages/track-regional-constraint/package.json
+++ b/packages/track-regional-constraint/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@broad/track-regional-constraint",
+  "version": "0.0.1",
+  "license": "MIT",
+  "main": "src/RegionalConstraintTrack.js",
+  "files": [
+    "lib"
+  ],
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "react": "^15.5.4",
+    "styled-components": "^2.1.2"
+  }
+}

--- a/packages/track-regional-constraint/package.json
+++ b/packages/track-regional-constraint/package.json
@@ -8,6 +8,7 @@
   ],
   "dependencies": {
     "@broad/help": "*",
+    "@broad/ui": "*",
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {

--- a/packages/track-regional-constraint/src/RegionalConstraintTrack.js
+++ b/packages/track-regional-constraint/src/RegionalConstraintTrack.js
@@ -1,0 +1,82 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-top: 5px;
+`
+
+
+const LeftPanel = styled.div`
+  align-items: center;
+  display: flex;
+  width: ${props => props.width}px;
+`
+
+
+const CenterPanel = styled.div`
+  display: flex;
+  align-items: center;
+  width: ${props => props.width}px;
+`
+
+
+export default function RegionalConstraintTrack({
+  height,
+  leftPanelWidth,
+  positionOffset,
+  regionalConstraintData,
+  strand,
+  width,
+  xScale,
+}) {
+  return (
+    <Container>
+      <LeftPanel width={leftPanelWidth}>
+        <p>Regional constraint</p>
+      </LeftPanel>
+      <CenterPanel width={width}>
+        <svg height={height} width={width}>
+          {regionalConstraintData.map((region) => {
+            const regionStart = strand === '+'
+              ? region.genomic_start
+              : region.genomic_end
+            const regionStop = strand === '+'
+              ? region.genomic_end
+              : region.genomic_start
+
+            const regionStartPos = xScale(positionOffset(regionStart).offsetPosition)
+            const regionStopPos = xScale(positionOffset(regionStop).offsetPosition)
+
+            return (
+              <g key={region.region_name}>
+                <rect
+                  x={regionStartPos}
+                  y={0}
+                  width={regionStopPos - regionStartPos}
+                  height={height}
+                  fill="rgb(255, 88, 63)"
+                  strokeWidth={1}
+                  stroke="black"
+                  opacity={0.2}
+                />
+              </g>
+            )
+          })}
+        </svg>
+      </CenterPanel>
+    </Container>
+  )
+}
+
+RegionalConstraintTrack.propTypes = {
+  regionalConstraintData: PropTypes.arrayOf(PropTypes.shape({
+    genomic_end: PropTypes.number.isRequired,
+    genomic_start: PropTypes.number.isRequired,
+    region_name: PropTypes.string.isRequired,
+  })).isRequired,
+  strand: PropTypes.oneOf(['+', '-']).isRequired,
+}

--- a/packages/track-regional-constraint/src/RegionalConstraintTrack.js
+++ b/packages/track-regional-constraint/src/RegionalConstraintTrack.js
@@ -3,6 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { QuestionMark } from '@broad/help'
+import { withTooltip } from '@broad/ui'
 
 
 const Container = styled.div`
@@ -24,6 +25,39 @@ const CenterPanel = styled.div`
   align-items: center;
   width: ${props => props.width}px;
 `
+
+
+const RegionAttributeList = styled.dl`
+  margin: 0;
+
+  div {
+    margin-bottom: 0.25em;
+  }
+
+  dt {
+    display: inline;
+    font-weight: bold;
+  }
+
+  dd {
+    display: inline;
+    margin-left: 0.5em;
+  }
+`
+
+
+const WithRegionTooltip = withTooltip(({ region }) => (
+  <RegionAttributeList>
+    <div>
+      <dt>O/E missense:</dt>
+      <dd>{region.obs_exp && region.obs_exp.toFixed(4)}</dd>
+    </div>
+    <div>
+      <dt>&chi;<sup>2</sup>:</dt>
+      <dd>{region.chisq_diff_null && region.chisq_diff_null.toFixed(4)}</dd>
+    </div>
+  </RegionAttributeList>
+))
 
 
 export default function RegionalConstraintTrack({
@@ -55,7 +89,10 @@ export default function RegionalConstraintTrack({
             const regionStopPos = xScale(positionOffset(regionStop).offsetPosition)
 
             return (
-              <g key={region.region_name}>
+              <WithRegionTooltip
+                key={region.region_name}
+                region={region}
+              >
                 <rect
                   x={regionStartPos}
                   y={0}
@@ -64,7 +101,7 @@ export default function RegionalConstraintTrack({
                   fill="rgba(255, 88, 63, 0.2)"
                   stroke="black"
                 />
-              </g>
+              </WithRegionTooltip>
             )
           })}
         </svg>

--- a/packages/track-regional-constraint/src/RegionalConstraintTrack.js
+++ b/packages/track-regional-constraint/src/RegionalConstraintTrack.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 
+import { QuestionMark } from '@broad/help'
+
 
 const Container = styled.div`
   display: flex;
@@ -37,6 +39,7 @@ export default function RegionalConstraintTrack({
     <Container>
       <LeftPanel width={leftPanelWidth}>
         <p>Regional constraint</p>
+        <QuestionMark topic="regional-constraint" display="inline" />
       </LeftPanel>
       <CenterPanel width={width}>
         <svg height={height} width={width}>

--- a/packages/track-regional-constraint/src/RegionalConstraintTrack.js
+++ b/packages/track-regional-constraint/src/RegionalConstraintTrack.js
@@ -61,10 +61,8 @@ export default function RegionalConstraintTrack({
                   y={0}
                   width={regionStopPos - regionStartPos}
                   height={height}
-                  fill="rgb(255, 88, 63)"
-                  strokeWidth={1}
+                  fill="rgba(255, 88, 63, 0.2)"
                   stroke="black"
-                  opacity={0.2}
                 />
               </g>
             )

--- a/packages/track-regional-constraint/src/RegionalConstraintTrack.js
+++ b/packages/track-regional-constraint/src/RegionalConstraintTrack.js
@@ -46,6 +46,22 @@ const RegionAttributeList = styled.dl`
 `
 
 
+function regionColor(region) {
+  if (region.obs_exp > 0.6 || region.chisq_diff_null < 10.8) {
+    return '#e2e2e2'
+  }
+
+  // http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=3
+  if (region.obs_exp > 0.4) {
+    return '#ffeda0'
+  }
+  if (region.obs_exp > 0.2) {
+    return '#feb24c'
+  }
+  return '#f03b20'
+}
+
+
 const WithRegionTooltip = withTooltip(({ region }) => (
   <RegionAttributeList>
     <div>
@@ -100,7 +116,7 @@ export default function RegionalConstraintTrack({
                     y={0}
                     width={regionWidth}
                     height={height}
-                    fill="rgba(255, 88, 63, 0.2)"
+                    fill={regionColor(region)}
                     stroke="black"
                   />
                   {(regionWidth > 30) && (

--- a/packages/track-regional-constraint/src/RegionalConstraintTrack.js
+++ b/packages/track-regional-constraint/src/RegionalConstraintTrack.js
@@ -38,7 +38,7 @@ export default function RegionalConstraintTrack({
   return (
     <Container>
       <LeftPanel width={leftPanelWidth}>
-        <p>Regional constraint</p>
+        <p>Regional missense constraint</p>
         <QuestionMark topic="regional-constraint" display="inline" />
       </LeftPanel>
       <CenterPanel width={width}>

--- a/packages/track-regional-constraint/src/RegionalConstraintTrack.js
+++ b/packages/track-regional-constraint/src/RegionalConstraintTrack.js
@@ -87,20 +87,33 @@ export default function RegionalConstraintTrack({
 
             const regionStartPos = xScale(positionOffset(regionStart).offsetPosition)
             const regionStopPos = xScale(positionOffset(regionStop).offsetPosition)
+            const regionWidth = regionStopPos - regionStartPos
 
             return (
               <WithRegionTooltip
                 key={region.region_name}
                 region={region}
               >
-                <rect
-                  x={regionStartPos}
-                  y={0}
-                  width={regionStopPos - regionStartPos}
-                  height={height}
-                  fill="rgba(255, 88, 63, 0.2)"
-                  stroke="black"
-                />
+                <g>
+                  <rect
+                    x={regionStartPos}
+                    y={0}
+                    width={regionWidth}
+                    height={height}
+                    fill="rgba(255, 88, 63, 0.2)"
+                    stroke="black"
+                  />
+                  {(regionWidth > 30) && (
+                    <text
+                      x={(regionStartPos + regionStopPos) / 2}
+                      y={height / 2}
+                      dy="0.33em"
+                      textAnchor="middle"
+                    >
+                      {region.obs_exp.toFixed(2)}
+                    </text>
+                  )}
+                </g>
               </WithRegionTooltip>
             )
           })}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,12 +7,14 @@
     "lib"
   ],
   "dependencies": {
-    "mousetrap": "^1.6.1"
+    "mousetrap": "^1.6.1",
+    "react-popper": "^1.0.0"
   },
   "devDependencies": {},
   "peerDependencies": {
     "prop-types": "^15.5.10",
     "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "styled-components": "^2.1.2"
   }
 }

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -65,3 +65,7 @@ export {
   GeneAttributeValue,
   ItemWrapper,
 } from './genePage/geneInfoStyles'
+
+export {
+  withTooltip
+} from './tooltip/withTooltip'

--- a/packages/ui/src/tooltip/styles.js
+++ b/packages/ui/src/tooltip/styles.js
@@ -1,0 +1,86 @@
+import styled from 'styled-components'
+
+
+const BACKGROUND_COLOR = '#474747'
+
+const ARROW_HEIGHT = 4
+const ARROW_WIDTH = 8
+
+
+export const Container = styled.div`
+  align-items: center;
+  background-color: ${BACKGROUND_COLOR};
+  border-radius: 3px;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  font-family: Roboto, sans-serif;
+  font-size: 13px;
+  justify-content: center;
+  margin: ${ARROW_HEIGHT}px;
+  padding: 0.5em;
+  position: relative;
+  z-index: 2;
+`
+
+
+export const Arrow = styled.div`
+  position: absolute;
+  height: ${ARROW_WIDTH}px;
+  width: ${ARROW_WIDTH}px;
+
+  &::before {
+    border-style: solid;
+    content: '';
+    display: block;
+    height: 0;
+    margin: auto;
+    width: 0;
+  }
+
+  &[data-placement*="bottom"] {
+    left: 0;
+    top: 0;
+    height: ${ARROW_HEIGHT}px;
+    width: ${ARROW_WIDTH}px;
+    margin-top: -${ARROW_HEIGHT}px;
+    &::before {
+      border-color: transparent transparent ${BACKGROUND_COLOR} transparent;
+      border-width: 0 ${ARROW_WIDTH / 2}px ${ARROW_HEIGHT}px ${ARROW_WIDTH / 2}px;
+    }
+  }
+
+  &[data-placement*="top"] {
+    bottom: 0;
+    left: 0;
+    height: ${ARROW_HEIGHT}px;
+    width: ${ARROW_WIDTH}px;
+    margin-bottom: -${ARROW_HEIGHT}px;
+    &::before {
+      border-color: ${BACKGROUND_COLOR} transparent transparent transparent;
+      border-width: ${ARROW_HEIGHT}px ${ARROW_WIDTH / 2}px 0 ${ARROW_WIDTH / 2}px;
+    }
+  }
+
+  &[data-placement*="right"] {
+    left: 0;
+    height: ${ARROW_WIDTH}px;
+    width: ${ARROW_HEIGHT}px;
+    margin-left: -${ARROW_HEIGHT}px;
+    &::before {
+      border-color: transparent ${BACKGROUND_COLOR} transparent transparent;
+      border-width: ${ARROW_WIDTH / 2}px ${ARROW_HEIGHT}px ${ARROW_WIDTH / 2}px 0;
+    }
+  }
+
+  &[data-placement*="left"] {
+    right: 0;
+    height: ${ARROW_WIDTH}px;
+    width: ${ARROW_HEIGHT}px;
+    margin-right: -${ARROW_HEIGHT}px;
+    &::before {
+      border-color: transparent transparent transparent ${BACKGROUND_COLOR};
+      border-width: ${ARROW_WIDTH / 2}px 0 ${ARROW_WIDTH / 2}px ${ARROW_HEIGHT}px;
+    }
+  }
+`

--- a/packages/ui/src/tooltip/withTooltip.js
+++ b/packages/ui/src/tooltip/withTooltip.js
@@ -1,0 +1,94 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import ReactDOM from 'react-dom'
+
+// TODO: After upgrading to React 16, use react-popper's Manager/Popper/Reference
+import { InnerPopper } from 'react-popper/lib/cjs/Popper'
+
+import { Arrow, Container } from './styles'
+
+
+class TooltipAnchor extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    tooltipComponent: PropTypes.func.isRequired,
+  }
+
+  componentDidUpdate() {
+    if (this.containerElement) {
+      this.renderTooltipInPortal()
+    }
+  }
+
+  referenceElementRef = (el) => {
+    this.referenceElement = el
+  }
+
+  removeTooltip = () => {
+    if (this.containerElement) {
+      ReactDOM.unmountComponentAtNode(this.containerElement)
+      document.body.removeChild(this.containerElement)
+      this.containerElement = null
+    }
+  }
+
+  renderTooltipContent = ({ ref, style, placement, arrowProps }) => {
+    const {
+      children,
+      // https://reactjs.org/docs/jsx-in-depth.html#user-defined-components-must-be-capitalized
+      tooltipComponent: TooltipComponent,
+      ...otherProps
+    } = this.props
+
+    return (
+      <Container data-placement={placement} innerRef={ref} style={style}>
+        <TooltipComponent {...otherProps} />
+        <Arrow data-placement={placement} innerRef={arrowProps.ref} style={arrowProps.style} />
+      </Container>
+    )
+  }
+
+  renderTooltipInPortal = () => {
+    if (!this.containerElement) {
+      this.containerElement = document.createElement('div')
+      document.body.appendChild(this.containerElement)
+    }
+
+    // TODO: After upgrading to React 16, use ReactDOM.createPortal
+    ReactDOM.unstable_renderSubtreeIntoContainer(
+      this,
+      (
+        <InnerPopper
+          placement="top"
+          positionFixed
+          referenceElement={this.referenceElement}
+        >
+          {this.renderTooltipContent}
+        </InnerPopper>
+      ),
+      this.containerElement
+    )
+  }
+
+  render() {
+    return React.cloneElement(
+      React.Children.only(this.props.children),
+      {
+        onMouseEnter: this.renderTooltipInPortal,
+        onMouseLeave: this.removeTooltip,
+        ref: this.referenceElementRef,
+      }
+    )
+  }
+}
+
+
+export function withTooltip(Component) {
+  function WithTooltip(props) {
+    return (
+      <TooltipAnchor {...props} tooltipComponent={Component} />
+    )
+  }
+  WithTooltip.displayName = `WithTooltip(${Component.displayName || Component.name || 'Component'})`
+  return WithTooltip
+}

--- a/projects/gnomad/package.json
+++ b/projects/gnomad/package.json
@@ -22,6 +22,7 @@
     "@broad/track-coverage": "*",
     "@broad/track-genes": "*",
     "@broad/track-navigator": "*",
+    "@broad/track-regional-constraint": "*",
     "@broad/track-stacked-bar": "*",
     "@broad/track-transcript": "*",
     "@broad/track-variant": "*",

--- a/projects/gnomad/src/GenePage/RegionViewer.js
+++ b/projects/gnomad/src/GenePage/RegionViewer.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 import { NavigatorTrackConnected } from '@broad/track-navigator'
 import { TranscriptTrackConnected } from '@broad/track-transcript'
 import CoverageTrack from '@broad/track-coverage'
+import RegionalConstraintTrack from '@broad/track-regional-constraint'
 import VariantTrack from '@broad/track-variant'
 // import StackedBarTrack from '@broad/track-stacked-bar'
 import { screenSize, SectionTitle } from '@broad/ui'
@@ -101,93 +102,6 @@ const GeneViewer = ({
     genome_coverage
   )
 
-  const RegionalConstraintTrackWrapper = styled.div`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    width: 100%;
-    height: 100%;
-  `
-
-  const RegionalConstraintLeft = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    width: ${props => props.leftPanelWidth}px;
-  `
-
-  const RegionalConstraintText = styled.p`
-    height: 100%;
-  `
-
-  const RegionalConstraintData = styled.div`
-    height: 100%;
-  `
-
-  const RegionalConstraintRegion = styled.rect`
-  `
-
-  const RegionalConstraintTrack = ({
-    regionalConstraintData,
-    leftPanelWidth,
-    xScale,
-    positionOffset,
-    width,
-    height,
-    strand,
-  }) => {
-    const padding = 2
-    return (
-      <RegionalConstraintTrackWrapper>
-        <RegionalConstraintLeft leftPanelWidth={leftPanelWidth} >
-          <RegionalConstraintText>Regional constraint</RegionalConstraintText>
-        </RegionalConstraintLeft>
-        <RegionalConstraintData>
-          <svg height={height} width={width}>
-            {/* <rect
-              x={0}
-              y={0}
-              width={width / 2}
-              height={height}
-              fill={'yellow'}
-              stroke={'black'}
-            /> */}
-            {regionalConstraintData.map((region) => {
-              const regionStart = strand === '+' ? region.genomic_start : region.genomic_end
-              const regionStop = strand === '+' ? region.genomic_end : region.genomic_start
-              const regionStartPos = positionOffset(regionStart).offsetPosition
-              const regionStopPos = positionOffset(regionStop).offsetPosition
-              return (
-                <g key={region.region_name}>
-                  <RegionalConstraintRegion
-                    x={xScale(regionStartPos)}
-                    y={padding}
-                    width={xScale(regionStopPos) - xScale(regionStartPos)}
-                    height={height - padding}
-                    fill={'rgb(255, 88, 63)'}
-                    // fill={'transparent'}
-                    strokeWidth={1}
-                    stroke={'black'}
-                    opacity={0.2}
-                  />
-                  <text
-                    x={(xScale(regionStopPos) + xScale(regionStartPos)) / 2}
-                    y={height / 2 + 6}
-                    textAnchor={'middle'}
-                  >
-                    {/* {region.region_name} */}
-                  </text>
-                </g>
-              )
-            })}
-          </svg>
-        </RegionalConstraintData>
-      </RegionalConstraintTrackWrapper>
-    )
-  }
-
   const RegionViewerSectionTitle = SectionTitle.extend`
     margin-left: 80px;
     @media (max-width: 900px) {
@@ -234,7 +148,7 @@ const GeneViewer = ({
         />
         {regionalConstraint.length > 0 && selectedVariantDataset === 'exacVariants' &&
           <RegionalConstraintTrack
-            height={17}
+            height={15}
             regionalConstraintData={regionalConstraint}
             strand={strand}
           />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1558,7 +1558,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -2703,6 +2703,13 @@ create-react-class@^15.6.0:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+create-react-context@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
 
 cron@^1.3:
   version "1.3.0"
@@ -4135,6 +4142,18 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
+fbjs@^0.8.0:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.5:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
@@ -4673,6 +4692,10 @@ growl@1.10.3:
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gzip-size@^3.0.0:
   version "3.0.0"
@@ -7483,6 +7506,10 @@ pmx@^1.5:
     json-stringify-safe "^5.0"
     vxx "^1.2.0"
 
+popper.js@^1.14.1:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
+
 portfinder@^1.0.13, portfinder@^1.0.9:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.13.tgz#bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9"
@@ -8188,7 +8215,7 @@ prop-types@15.5.10, prop-types@^15.5.10, prop-types@^15.5.4:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
-prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -8478,6 +8505,17 @@ react-motion@^0.5.0:
     performance-now "^0.2.0"
     prop-types "^15.5.8"
     raf "^3.1.0"
+
+react-popper@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.0.0.tgz#b99452144e8fe4acc77fa3d959a8c79e07a65084"
+  dependencies:
+    babel-runtime "6.x.x"
+    create-react-context "^0.2.1"
+    popper.js "^1.14.1"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.5"
+    warning "^3.0.0"
 
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
@@ -10479,6 +10517,10 @@ type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
+typed-styles@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.5.tgz#a60df245d482a9b1adf9c06c078d0f06085ed1cf"
+
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -10489,6 +10531,10 @@ typescript-eslint-parser@^7.0.0:
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.3.0"
+
+ua-parser-js@^0.7.18:
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
 ua-parser-js@^0.7.9:
   version "0.7.14"


### PR DESCRIPTION
* Color regions based on their significance and observed/expected missense.
* Show observed/expected missense in region.
* Add help button.
* When hovering the mouse over a region, show a tooltip with observed/expected missense and significance. 
* For consistency with other Track components, move RegionalConstraintTrack into its own package instead of defining it inline in projects/gnomad/RegionViewer.

## Before
<img width="1110" alt="screen shot 2018-06-20 at 10 12 52 am" src="https://user-images.githubusercontent.com/1156625/41663997-b93f1d32-7472-11e8-9e72-07caf8488a31.png">

## After
<img width="1087" alt="screen shot 2018-06-20 at 10 13 34 am" src="https://user-images.githubusercontent.com/1156625/41663998-b9502f50-7472-11e8-8783-d6598486b18f.png">
<img width="990" alt="screen shot 2018-06-20 at 10 12 24 am" src="https://user-images.githubusercontent.com/1156625/41663999-b95db314-7472-11e8-8786-c7894e7922ff.png">
