### PR TITLE
Fix number of variants visible in table

### DIFF
--- a/packages/track-navigator/src/Navigator.js
+++ b/packages/track-navigator/src/Navigator.js
@@ -85,7 +85,7 @@ const ClickArea = ({
   if (variants.size === 0) {
     return <p></p>
   }
-  const numberOfVariantsVisibleInTable = 18
+  const numberOfVariantsVisibleInTable = 20
   const { scrollHeight, scrollTop } = currentTableScrollData
   const scrollSync = Math.floor((scrollTop / scrollHeight) * variants.size)
   let currentlyVisibleVariants


### PR DESCRIPTION
Resolves https://github.com/macarthur-lab/gnomad_browser/issues/112

The "Viewing in table" track assumes 18 rows are visible in the table. However, 20 row are actually visible. This results in some variants that do appear in the table not appearing in the "Viewing in table" track.

To reproduce:
* Navigate to /gene/RBM20
* Filter to LoF
* Scroll to bottom of table

Before:
<img width="1011" alt="screen shot 2018-05-07 at 5 41 41 pm" src="https://user-images.githubusercontent.com/1156625/39726811-585732aa-521e-11e8-91c5-758dd2477552.png">

After:
<img width="1014" alt="screen shot 2018-05-07 at 5 32 21 pm" src="https://user-images.githubusercontent.com/1156625/39726816-5d25c756-521e-11e8-816e-69257ab7d71a.png">
