### PR TITLE
Remove dependencies on plot-traffic package

### DIFF
--- a/packages/export-pdf/package.json
+++ b/packages/export-pdf/package.json
@@ -3,16 +3,18 @@
   "version": "0.0.1",
   "license": "MIT",
   "main": "src/index.js",
+  "scripts": {
+    "example": "babel-node src/example/index.js"
+  },
   "files": [
     "lib"
   ],
   "localDependencies": {},
   "dependencies": {
-    "html-pdf": "^2.1.0",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "html-pdf": "^2.1.0"
   },
   "peerDependencies": {
-    "react": "^15.5.4"
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
   }
 }

--- a/packages/export-pdf/package.json
+++ b/packages/export-pdf/package.json
@@ -16,5 +16,8 @@
   "peerDependencies": {
     "react": "^15.5.4",
     "react-dom": "^15.5.4"
+  },
+  "devDependencies": {
+    "prop-types": "15.5.10"
   }
 }

--- a/packages/export-pdf/src/example/index.js
+++ b/packages/export-pdf/src/example/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import InlineCss from 'react-inline-css'
 import { TrafficBar } from '@broad/plot-traffic'
 import { generateComponentAsPDF } from '../index'
 

--- a/packages/export-pdf/src/example/index.js
+++ b/packages/export-pdf/src/example/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
 import { generateComponentAsPDF } from '../index'
@@ -6,6 +7,10 @@ const TestComponent = ({ message }) => {
   return (
     <h1>This is a test! {message}</h1>
   )
+}
+
+TestComponent.propTypes = {
+  message: PropTypes.string.isRequired,
 }
 
 const options = {

--- a/packages/export-pdf/src/example/index.js
+++ b/packages/export-pdf/src/example/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { TrafficBar } from '@broad/plot-traffic'
+
 import { generateComponentAsPDF } from '../index'
 
 const TestComponent = ({ message }) => {
@@ -9,7 +9,7 @@ const TestComponent = ({ message }) => {
 }
 
 const options = {
-  component: TrafficBar,
+  component: TestComponent,
   props: { message: 'hello' },
   fileName: 'test.pdf',
 }

--- a/projects/demo/Makefile
+++ b/projects/demo/Makefile
@@ -28,10 +28,6 @@ watch:
 	@echo "  $(P) watch $(WATCH_FLAGS)"
 	@$(BIN_DIR)/watch $(WATCH_FLAGS)
 
-pdf:
-	./node_modules/.bin/babel-node node_modules/@broad/test/src/example
-	open /Users/msolomon/gnomadjs/packages/@broad/dev-server/node_modules/@broad/test/src/tmp/test.pdf
-
 serve:
 	@echo "  $(P) serve $(SERVER_FLAGS)" ; \
 	lsof -ti:8010 | xargs kill ; \

--- a/projects/demo/package.json
+++ b/projects/demo/package.json
@@ -7,7 +7,6 @@
     "@broad/fetch-hoc": "0.0.1",
     "@broad/pdf-export": "0.0.1",
     "@broad/plot": "0.0.1",
-    "@broad/plot-traffic": "0.0.1",
     "@broad/region": "0.0.1",
     "@broad/gene-page": "0.0.1",
     "@broad/test": "0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8513,7 +8513,7 @@ react-deep-force-update@^2.0.1, react-deep-force-update@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
 
-react-dom@^15.5.4, react-dom@^15.6.1:
+react-dom@^15.5.4:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
   dependencies:


### PR DESCRIPTION
Currently, plot-traffic is listed as a dependency for the demo project and the export-pdf package's example. However, plot-traffic isn't directly relevant to the browsers. It was a side project that rendered a graph of traffic to the gnomAD site. That being the case, it should be kept isolated to avoid adding unnecessary complexity to the rest of gnomadjs. The demo project doesn't use it and export-pdf can be demoed with a different (simpler) component.