### PR TITLE
Fix keyboard shortcuts for search

### DIFF
--- a/packages/gene-page/package.json
+++ b/packages/gene-page/package.json
@@ -28,7 +28,6 @@
     "d3-shape": "^1.2.0",
     "immutable": "^3.8.1",
     "keymirror": "^0.1.1",
-    "mousetrap": "^1.6.1",
     "prop-types": "^15.5.10",
     "redux-debounced": "^0.4.0",
     "redux-search": "^2.3.3"

--- a/packages/t2d/src/example/index.js
+++ b/packages/t2d/src/example/index.js
@@ -82,8 +82,6 @@ class T2dComponentsShowcase extends PureComponent {
         </ButtonGroup>
         <ControlPanel>
           <Search
-            listName={'search table'}
-            options={['Gene name']}
             placeholder={'Search gene'}
             onChange={this.setCurrentGene}
           />

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,9 @@
   "files": [
     "lib"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "mousetrap": "^1.6.1"
+  },
   "devDependencies": {},
   "peerDependencies": {
     "prop-types": "^15.5.10",

--- a/packages/ui/src/search/simpleSearch.js
+++ b/packages/ui/src/search/simpleSearch.js
@@ -1,5 +1,6 @@
-import React from 'react'
+import Mousetrap from 'mousetrap'
 import PropTypes from 'prop-types'
+import React, { Component } from 'react'
 import styled from 'styled-components'
 
 const SearchWrapper = styled.div`
@@ -9,69 +10,88 @@ const SearchWrapper = styled.div`
   align-items: center;
 `
 
-
 const SearchInput = styled.input`
   height: 25px;
   width: 210px;
   border: 0;
   border-bottom: 1px solid #000;
   background-color: transparent;
-  /*margin-top: 2px;*/
-  /*margin-right: 100px;*/
   text-indent: 5px;
   -webkit-transition: width 0.4s ease-in-out;
   transition: width 0.4s ease-in-out;
 `
 
-const ClearSearch = styled.button`
+const ClearSearchButton = styled.button`
   margin-left: 5px;
   height: 20px;
-
 `
 
-export const Search = ({
-  listName,
-  options,
-  placeholder,
-  onChange,
-  reference,
-}) => {
-  let elem
-  return (
-    <SearchWrapper>
+const SEARCH_KEYBOARD_SHORTCUTS = ['command+f', 'meta+s']
+
+export class Search extends Component {
+  static propTypes = {
+    placeholder: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    withKeyboardShortcuts: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    placeholder: 'Search',
+    withKeyboardShortcuts: false,
+  }
+
+  state = {
+    value: '',
+  }
+
+  componentDidMount() {
+    if (this.props.withKeyboardShortcuts) {
+      Mousetrap.bind(SEARCH_KEYBOARD_SHORTCUTS, (e) => {
+        if (this.input) {
+          e.preventDefault()
+          this.input.focus()
+        }
+      })
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.boundKeyboardShortcuts) {
+      Mousetrap.unbind(SEARCH_KEYBOARD_SHORTCUTS)
+    }
+  }
+
+  onChange = (e) => {
+    const value = e.target.value
+    this.setState({ value })
+    this.props.onChange(value)
+  }
+
+  onClear = () => {
+    this.setState({ value: '' })
+    this.props.onChange('')
+  }
+
+  inputRef = (el) => {
+    this.input = el
+  }
+
+  render() {
+    return (
+      <SearchWrapper>
         <SearchInput
-          type="text"
-          name="search"
           autoComplete="off"
-          placeholder={placeholder}
-          ref={e1 => {
-            elem = e1
-          }}
-          list={listName}
-          onChange={(event) => {
-            event.preventDefault()
-            onChange(event.target.value)
-          }}
+          onChange={this.onChange}
+          placeholder={this.props.placeholder}
+          innerRef={this.inputRef}
+          type="text"
+          value={this.state.value}
         />
-        {/* <datalist id={listName}>
-          {options.map(item => <option value={item} />)}
-        </datalist> */}
-      <ClearSearch onClick={() => {
-        onChange('')
-        elem.inputText = ''
-      }}>Clear</ClearSearch>
-    </SearchWrapper>
-  )
-}
-Search.propTypes = {
-  listName: PropTypes.string,
-  // options: PropTypes.string,
-  placeholder: PropTypes.string,
-  // onSubmit: PropTypes.string,
-}
-Search.defaultProps = {
-  listName: 'myList',
-  options: ['first', 'second', 'third'],
-  placeholder: 'placeholder',
-  onSubmit: console.log,
+        <ClearSearchButton
+          onClick={this.onClear}
+          type="button"
+        >Clear</ClearSearchButton>
+      </SearchWrapper>
+    )
+  }
 }

--- a/projects/dblof/package.json
+++ b/projects/dblof/package.json
@@ -52,7 +52,6 @@
     "d3-shape": "^1.2.0",
     "graphql-fetch": "^1.0.1",
     "isomorphic-fetch": "^2.2.1",
-    "mousetrap": "^1.6.1",
     "normalize.css": "^6.0.0",
     "ramda": "^0.24.1",
     "react": "^15.5.4",

--- a/projects/gnomad/package.json
+++ b/projects/gnomad/package.json
@@ -32,7 +32,6 @@
     "d3-shape": "^1.2.0",
     "graphql-fetch": "^1.0.1",
     "isomorphic-fetch": "^2.2.1",
-    "mousetrap": "^1.6.1",
     "prop-types": "^15.5.10",
     "ramda": "^0.24.1",
     "react-redux": "^5.0.4",

--- a/projects/gnomad/src/Settings.js
+++ b/projects/gnomad/src/Settings.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
-import Mousetrap from 'mousetrap'
 
 import {
   actions as variantActions,
@@ -30,13 +29,6 @@ import {
 } from '@broad/ui'
 
 import { QuestionMark } from '@broad/help'
-
-let findInput
-
-Mousetrap.bind(['command+f', 'meta+s'], (e) => {
-  e.preventDefault()
-  findInput.focus()
-})
 
 const GeneSettings = ({
   exonPadding,
@@ -146,11 +138,9 @@ const GeneSettings = ({
           </form>
           <SearchContainer>
             <Search
-              listName={'search table'}
-              options={['Variant ID', 'RSID', 'HGVSp']}
               placeholder={'Search variant table'}
-              reference={findInput}
               onChange={searchVariants}
+              withKeyboardShortcuts
             />
           </SearchContainer>
         </DataSelectionGroup>

--- a/projects/schizophrenia/package.json
+++ b/projects/schizophrenia/package.json
@@ -6,7 +6,7 @@
   "author": "Matthew Solomonson <msolomon@broadinstitute.org>",
   "license": "MIT",
   "scripts": {
-    "start": "GNOMAD_API_URL='http://localhost:8007' ../../node_modules/.bin/webpack-dev-server --port 8012 --hot --config ../../webpack.config.js"
+    "start": "GNOMAD_API_URL='http://gnomad-api2.broadinstitute.org' ../../node_modules/.bin/webpack-dev-server --port 8012 --hot --config ../../webpack.config.js"
 
   },
   "files": [
@@ -27,7 +27,6 @@
     "d3-shape": "^1.2.0",
     "graphql-fetch": "^1.0.1",
     "isomorphic-fetch": "^2.2.1",
-    "mousetrap": "^1.6.1",
     "prop-types": "^15.5.10",
     "ramda": "^0.24.1",
     "react": "^15.5.4",

--- a/projects/schizophrenia/src/ExomePage/GeneSettings.js
+++ b/projects/schizophrenia/src/ExomePage/GeneSettings.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
 
-import Mousetrap from 'mousetrap'
-
 import {
   actions as variantActions,
   selectedVariantDataset,
@@ -13,22 +11,15 @@ import {
 } from '@broad/redux-variants'
 
 import { currentGene, geneData, exonPadding } from '@broad/redux-genes'
-import { Search } from '@broad/ui/src/search/simpleSearch'
 
 import {
   MaterialButtonRaised,
   SettingsContainer,
   MenusContainer,
+  Search,
   SearchContainer,
   DataSelectionGroup,
 } from '@broad/ui'
-
-let findInput
-
-Mousetrap.bind(['command+f', 'meta+s'], function(e) {  // eslint-disable-line
-  e.preventDefault()
-  findInput.focus()
-})
 
 const GeneSettings = ({
   searchVariants,
@@ -95,11 +86,9 @@ const GeneSettings = ({
         <DataSelectionGroup>
           <SearchContainer>
             <Search
-              listName={'search table'}
-              options={['Variant ID', 'RSID', 'HGVSp']}
               placeholder={'Search variant table'}
-              reference={findInput}
               onChange={searchVariants}
+              withKeyboardShortcuts
             />
           </SearchContainer>
         </DataSelectionGroup>

--- a/projects/schizophrenia/src/GwasPage/RegionSettings.js
+++ b/projects/schizophrenia/src/GwasPage/RegionSettings.js
@@ -11,16 +11,13 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
 
-import Mousetrap from 'mousetrap'
-
 import {
   actions as variantActions,
   selectedVariantDataset,
 } from '@broad/redux-variants'
 
 import { currentGene, exonPadding, geneData } from '@broad/redux-genes'
-import { MaterialButtonRaised } from '@broad/ui'
-import { Search } from '@broad/ui/src/search/simpleSearch'
+import { MaterialButtonRaised, Search } from '@broad/ui'
 
 import {
   SettingsContainer,
@@ -28,13 +25,6 @@ import {
   SearchContainer,
   DataSelectionGroup,
 } from '@broad/ui'
-
-let findInput
-
-Mousetrap.bind(['command+f', 'meta+s'], function(e) {  // eslint-disable-line
-  e.preventDefault()
-  findInput.focus()
-})
 
 const GeneSettings = ({
   searchVariants,
@@ -74,11 +64,9 @@ const GeneSettings = ({
         <DataSelectionGroup>
           <SearchContainer>
             <Search
-              listName={'search table'}
-              options={['Variant ID', 'RSID', 'HGVSp']}
               placeholder={'Search variant table'}
-              reference={findInput}
               onChange={searchVariants}
+              withKeyboardShortcuts
             />
           </SearchContainer>
         </DataSelectionGroup>

--- a/projects/variantfx/package.json
+++ b/projects/variantfx/package.json
@@ -34,7 +34,6 @@
     "immutable": "^3.8.2",
     "isomorphic-fetch": "^2.2.1",
     "keymirror": "^0.1.1",
-    "mousetrap": "^1.6.1",
     "prop-types": "^15.5.10",
     "ramda": "^0.24.1",
     "react": "^15.5.4",

--- a/projects/variantfx/src/GenePage/GeneSettings.js
+++ b/projects/variantfx/src/GenePage/GeneSettings.js
@@ -2,30 +2,21 @@ import React, { PropTypes } from 'react'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
 
-import Mousetrap from 'mousetrap'
-
 import {
   actions as variantActions,
   selectedVariantDataset,
 } from '@broad/redux-variants'
 
 import { geneData, currentGene, exonPadding } from '@broad/redux-genes'
-import { Search } from '@broad/ui/src/search/simpleSearch'
 
 import {
   MaterialButtonRaised,
   SettingsContainer,
   MenusContainer,
+  Search,
   SearchContainer,
   DataSelectionGroup,
 } from '@broad/ui'
-
-let findInput
-
-Mousetrap.bind(['command+f', 'meta+s'], function(e) {  // eslint-disable-line
-  e.preventDefault()
-  findInput.focus()
-})
 
 const GeneSettings = ({
   searchVariants,
@@ -65,11 +56,9 @@ const GeneSettings = ({
         <DataSelectionGroup>
           <SearchContainer>
             <Search
-              listName={'search table'}
-              options={['Variant ID', 'RSID', 'HGVSp']}
               placeholder={'Search variant table'}
-              reference={findInput}
               onChange={searchVariants}
+              withKeyboardShortcuts
             />
           </SearchContainer>
         </DataSelectionGroup>


### PR DESCRIPTION
Resolves #65.

* Moves handling of global keyboard shortcuts for searching into the search component.
* Remove `mousetrap` dependency from other packages/projects.
* Change imports from `@broad/ui/src/search/simpleSearch` to import from `@broad/ui`.