### PR TITLE
Remove unused history argument from setFocusedVariant action

### DIFF
--- a/packages/redux-variants/variants.js
+++ b/packages/redux-variants/variants.js
@@ -31,17 +31,7 @@ export const types = keymirror({
 export const actions = {
   setHoveredVariant: variantId => ({ type: types.SET_HOVERED_VARIANT, variantId }),
 
-  setFocusedVariant: (variantId, history) => (dispatch, getState) => {
-    // history.push(`/gene/BRCA2/${variantId}`)
-    // HACK way to preserve table state when switching to variant table
-    // dispatch(tableActions.setCurrentTableIndex(
-    //   getTableIndexByPosition(
-    //     variantId.split('-')[1],
-    //     finalFilteredVariants(getState())
-    //   ) + 7
-    // ))
-    dispatch(({ type: types.SET_FOCUSED_VARIANT, variantId }))
-  },
+  setFocusedVariant: variantId => ({ type: types.SET_FOCUSED_VARIANT, variantId }),
 
   setSelectedVariantDataset: variantDataset =>
     ({ type: types.SET_SELECTED_VARIANT_DATASET, variantDataset }),

--- a/packages/table/src/VariantTable.js
+++ b/packages/table/src/VariantTable.js
@@ -71,7 +71,7 @@ const VariantTable = ({
         loadMoreRows={() => {}}
         overscan={5}
         loadLookAhead={0}
-        onRowClick={setFocusedVariant(history)}
+        onRowClick={setFocusedVariant}
         onRowHover={setHoveredVariant}
         scrollToRow={tablePosition}
         onScroll={setCurrentTableScrollData}
@@ -118,12 +118,11 @@ const mapDispatchToProps = (dispatch) => {
   return {
     setVariantSort: sortKey => dispatch(variantActions.setVariantSort(sortKey)),
 
-    setFocusedVariant: history => (variantId, dataset) => {
-      console.log(dataset)
+    setFocusedVariant: (variantId, dataset) => {
       if (dataset === 'exacVariants') {
         window.open(`http://exac.broadinstitute.org/variant/${variantId}`)
       } else if (dataset === 'schizophreniaRareVariants') {
-        dispatch(variantActions.setFocusedVariant(variantId, history))
+        dispatch(variantActions.setFocusedVariant(variantId))
       } else {
         window.open(`http://gnomad-beta.broadinstitute.org/variant/${variantId}`)
       }


### PR DESCRIPTION
`setFocusedVariant` doesn't use its `history` argument. VariantTable's only reason for accepting `history` as a prop was to pass it to `setFocusedVariant`. Thus, this clears the way to remove the `withRouter` wrapper from around VariantTable.