### PR TITLE
Tweak SCHEMA home page styles

### DIFF
--- a/projects/schizophrenia/public/index.html
+++ b/projects/schizophrenia/public/index.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/7.0.0/normalize.min.css">
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
     <link type="image/x-icon" rel="shortcut icon" />
     <style>
       * {

--- a/projects/schizophrenia/src/HomePage.js
+++ b/projects/schizophrenia/src/HomePage.js
@@ -8,24 +8,18 @@ const HomePageWrapper = styled.section`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 80%;
   align-items: center;
-  margin-top: 80px;
-  margin-left: 50px;
-  margin-right: 50px;
-  ${'' /* border: 1px solid blue; */}
+  margin: 80px 50px 50px;
 `
 
 const TitleGroup = styled.div`
   display: flex;
   flex-direction: column;
   max-width: 60%;
-  ${'' /* border: 1px solid red; */}
 `
 
 const Title = styled.h1`
   font-family: Roboto;
-  ${'' /* font-family: "HelveticaNeue-CondensedBold"; */}
   font-size: 60px;
   font-weight: bold;
   margin-bottom: 5px;
@@ -56,7 +50,6 @@ const Announcements = styled.div`
   align-self: center;
   margin-top: 10px;
   width: 100%;
-${'' /* border: 1px soliinspectord #000; */}
 `
 
 const AnnouncementsTitle = styled.h2`
@@ -83,9 +76,6 @@ const AnnouncementParagraphText = ParagraphText.extend`
 const Logos = styled.div`
   display: flex;
   margin-top: 20px;
-  ${'' /* width: 100%; */}
-  ${'' /* border: 1px solid #000; */}
-
 `
 
 const imageSettings = {


### PR DESCRIPTION
* Load Roboto and FontAwesome fonts which are used by SCHEMA's CSS
* Prevent home page content from overlapping on short windows (caused by constraining the HomePageWrapper component to 80% of the window height)