### PR TITLE
Change layout of variant details section in SCHEMA browser

### DIFF
--- a/projects/schizophrenia/src/ExomePage/index.js
+++ b/projects/schizophrenia/src/ExomePage/index.js
@@ -19,11 +19,11 @@ import {
   Summary,
 } from '@broad/ui'
 
+import VariantDetails from '../VariantDetails'
 import GeneInfo from './GeneInfo'
 import GeneSettings from './GeneSettings'
 import RegionViewer from './RegionViewer'
 import tableConfig from './tableConfig'
-import VariantDetails from './VariantPage'
 import { fetchSchz } from './fetch'
 
 const VariantTableWithRouter = withRouter(VariantTable)

--- a/projects/schizophrenia/src/VariantDetails/AnalysisGroupsTable.js
+++ b/projects/schizophrenia/src/VariantDetails/AnalysisGroupsTable.js
@@ -1,0 +1,87 @@
+import gql from 'graphql-tag'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { graphql } from 'react-apollo'
+
+import {
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+  TableRows,
+} from '@broad/ui'
+
+
+export function BaseAnalysisGroupsTable({ groups }) {
+  return (
+    <Table>
+      <TableRows>
+        <TableHeader>
+          <TableCell width={'200px'}>Group</TableCell>
+          <TableCell width={'80px'}>Cases</TableCell>
+          <TableCell width={'80px'}>Controls</TableCell>
+          <TableCell width={'80px'}>P-value</TableCell>
+          <TableCell width={'80px'}>Beta</TableCell>
+        </TableHeader>
+        {groups.map(group => (
+          <TableRow key={group.group}>
+            <TableCell width={'200px'}>{group.group}</TableCell>
+            <TableCell width={'80px'}>{group.ac_case}</TableCell>
+            <TableCell width={'80px'}>{group.ac_ctrl}</TableCell>
+            <TableCell width={'80px'}>{group.pval}</TableCell>
+            <TableCell width={'80px'}>{group.beta}</TableCell>
+          </TableRow>
+        ))}
+      </TableRows>
+    </Table>
+  )
+}
+
+BaseAnalysisGroupsTable.propTypes = {
+  groups: PropTypes.arrayOf(PropTypes.shape({
+    group: PropTypes.string.isRequired,
+    ac_case: PropTypes.number.isRequired,
+    ac_ctrl: PropTypes.number.isRequired,
+    pval: PropTypes.number.isRequired,
+    beta: PropTypes.number.isRequired,
+  })).isRequired,
+}
+
+
+const analysisGroupsQuery = gql`
+  query AnalysisGroups(
+    $variantId: String,
+  ) {
+    groups: schzGroups(variant_id: $variantId) {
+      pos
+      xpos
+      pval
+      ac_case
+      contig
+      beta
+      variant_id
+      an_ctrl
+      an_case
+      group
+      ac_ctrl
+      allele_freq
+    }
+}
+`
+
+const ConnectedAnalysisGroupsTable = graphql(
+  analysisGroupsQuery,
+  {
+    options: ({ variantId }) => ({
+      variables: { variantId },
+      errorPolicy: 'ignore'
+    })
+  }
+)(({ data: { loading, groups } }) => {
+  if (loading) {
+    return <span>Loading groups...</span>
+  }
+  return <BaseAnalysisGroupsTable groups={groups} />
+})
+
+export default ConnectedAnalysisGroupsTable

--- a/projects/schizophrenia/src/VariantDetails/VariantAttributes.js
+++ b/projects/schizophrenia/src/VariantDetails/VariantAttributes.js
@@ -1,0 +1,48 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+
+const VariantAttributeLabel = styled.dt`
+  display: inline;
+  font-weight: bold;
+`
+
+const VariantAttributeValue = styled.dd`
+  display: inline;
+  margin-left: 0.5em;
+`
+
+const VariantAttributeListItem = styled.div`
+  margin-bottom: 0.25em;
+`
+
+export function VariantAttribute({ children, label }) {
+  return (
+    <VariantAttributeListItem>
+      <VariantAttributeLabel>{label}:</VariantAttributeLabel>
+      <VariantAttributeValue>{children}</VariantAttributeValue>
+    </VariantAttributeListItem>
+  )
+}
+
+VariantAttribute.propTypes = {
+  children: PropTypes.node.isRequired,
+  label: PropTypes.string.isRequired,
+}
+
+export function VariantAttributeList({ children, label }) {
+  return (
+    <div>
+      <h2>{label}</h2>
+      <dl>
+        {children}
+      </dl>
+    </div>
+  )
+}
+
+VariantAttributeList.propTypes = {
+  children: PropTypes.node.isRequired,
+  label: PropTypes.string.isRequired,
+}

--- a/projects/schizophrenia/src/VariantDetails/VariantDetails.js
+++ b/projects/schizophrenia/src/VariantDetails/VariantDetails.js
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { singleVariantData } from '@broad/redux-variants'
 
 import AnalysisGroupsTable from './AnalysisGroupsTable'
+import { VariantAttribute, VariantAttributeList } from './VariantAttributes'
 
 
 const VariantContainer = styled.div`
@@ -24,6 +25,7 @@ const Columns = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: space-between;
+  margin: 1em 0;
 
   ${Column} {
     flex-basis: calc(33% - 1em);
@@ -42,21 +44,15 @@ const Columns = styled.div`
   }
 `
 
-const VariantAttributes = styled.div`
-  align-items: space-between;
-  display: flex;
-  flex-direction: column;
-  margin: 10px 0;
-`
-
-const VariantAttribute = styled.div`
-  margin-bottom: 2px;
-`
-
 const TranscriptAttributes = styled.dl`
-  margin-top: 0;
-  dt, dd {
+  margin: 0 0 0.25em 0.5em;
+
+  dt {
     display: inline;
+  }
+  dd {
+    display: inline;
+    margin-left: 0.25em;
   }
 `
 
@@ -103,6 +99,10 @@ function formatPolyPhen(abbreviation) {
   }
 }
 
+function formatAlleleFrequency(frequency) {
+  return Number(frequency.toPrecision(4)).toExponential()
+}
+
 const Variant = ({ variant }) => {
   if (!variant) {
     return null
@@ -130,98 +130,93 @@ const Variant = ({ variant }) => {
       <Link href={`http://gnomad.broadinstitute.org/variant/${variant.variant_id}`}>View in gnomAD</Link>
       <Columns>
         <Column>
-          <VariantAttributes>
-            <h2>Statistics</h2>
-            <VariantAttribute>
-              <strong>Cases:</strong> {variant.ac_case} / {variant.an_case} ({Number(variant.af_case.toPrecision(4)).toExponential()})
+          <VariantAttributeList label="Statistics">
+            <VariantAttribute label="Cases">
+              {variant.ac_case} / {variant.an_case} ({formatAlleleFrequency(variant.af_case)})
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>Controls:</strong> {variant.ac_ctrl} / {variant.an_ctrl}  ({Number(variant.af_ctrl.toPrecision(4)).toExponential()})
+            <VariantAttribute label="Controls">
+              {variant.ac_ctrl} / {variant.an_ctrl} ({formatAlleleFrequency(variant.af_ctrl)})
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>N analysis groups:</strong> {variant.n_analysis_groups}
+            <VariantAttribute label="N analysis groups">
+              {variant.n_analysis_groups}
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>N denovos:</strong> {variant.ac_denovo}
+            <VariantAttribute label="N denovos">
+              {variant.ac_denovo}
             </VariantAttribute>
-          </VariantAttributes>
+          </VariantAttributeList>
 
           {variant.pval_meta !== null && (
-            <VariantAttributes>
-              <h2>Analysis</h2>
-              <VariantAttribute>
-                <strong>Meta P-Value:</strong> {Number(variant.pval_meta.toPrecision(3)).toExponential()}
+            <VariantAttributeList label="Analysis">
+              <VariantAttribute label="Meta P-Value">
+                {Number(variant.pval_meta.toPrecision(3)).toExponential()}
               </VariantAttribute>
-              <VariantAttribute>
-                <strong>Estimate:</strong> {Number(variant.estimate.toPrecision(3)).toExponential()}
+              <VariantAttribute label="Estimate">
+                {Number(variant.estimate.toPrecision(3)).toExponential()}
               </VariantAttribute>
-              <VariantAttribute>
-                <strong>SE:</strong> {variant.se}
+              <VariantAttribute label="SE">
+                {variant.se}
               </VariantAttribute>
-              <VariantAttribute>
-                <strong>Qp:</strong> {variant.qp}
+              <VariantAttribute label="Qp">
+                {variant.qp}
               </VariantAttribute>
-              <VariantAttribute>
-                <strong>I2:</strong> {variant.i2}
+              <VariantAttribute label="I2">
+                {variant.i2}
               </VariantAttribute>
-            </VariantAttributes>
+            </VariantAttributeList>
           )}
         </Column>
 
         <Column>
-          <VariantAttributes>
-            <h2>Annotations</h2>
-            <VariantAttribute>
-              <strong>HGVSc:</strong> {variant.hgvsc_canonical}
+          <VariantAttributeList label="Annotations">
+            <VariantAttribute label="HGVSc">
+              {variant.hgvsc_canonical}
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>HGVSp:</strong> {variant.hgvsp_canonical}
+            <VariantAttribute label="HGVSp">
+              {variant.hgvsp_canonical}
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>Consequence:</strong> {formatConsequence(variant.consequence)}
+            <VariantAttribute label="Consequence">
+              {formatConsequence(variant.consequence)}
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>MPC:</strong> {variant.mpc}
+            <VariantAttribute label="MPC">
+              {variant.mpc}
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>CADD:</strong> {variant.cadd}
+            <VariantAttribute label="CADD">
+              {variant.cadd}
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>PolyPhen:</strong> {formatPolyPhen(variant.polyphen)}
+            <VariantAttribute label="PolyPhen">
+              {formatPolyPhen(variant.polyphen)}
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>Flags:</strong> {variant.flags}
+            <VariantAttribute label="Flags">
+              {variant.flags}
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>Source:</strong> {variant.source}
+            <VariantAttribute label="Source">
+              {variant.source}
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>In analysis:</strong> {variant.in_analysis}
+            <VariantAttribute label="In analysis">
+              {variant.in_analysis}
             </VariantAttribute>
-            <VariantAttribute>
-              <strong>Comment:</strong> {variant.comment}
+            <VariantAttribute label="Comment">
+              {variant.comment}
             </VariantAttribute>
-          </VariantAttributes>
+          </VariantAttributeList>
         </Column>
 
         {variant.transcript_id && (
           <Column>
-            <VariantAttributes>
-              <h2>Transcripts</h2>
+            <VariantAttributeList label="Transcripts">
               {variant.transcript_id.split(',').map(tID => (
-                <VariantAttribute key={tID}>
-                  <strong>{tID}</strong>
+                <VariantAttribute key={tID} label={tID}>
                   <TranscriptAttributes>
                     <div>
-                      <dt>HGVSc</dt><dd>{transcriptHGVSc[tID]}</dd>
+                      <dt>HGVSc:</dt><dd>{transcriptHGVSc[tID]}</dd>
                     </div>
                     <div>
-                      <dt>HGVSp</dt><dd>{transcriptHGVSp[tID]}</dd>
+                      <dt>HGVSp:</dt><dd>{transcriptHGVSp[tID]}</dd>
                     </div>
                   </TranscriptAttributes>
                 </VariantAttribute>
               ))}
-            </VariantAttributes>
+            </VariantAttributeList>
           </Column>
         )}
       </Columns>

--- a/projects/schizophrenia/src/VariantDetails/VariantDetails.js
+++ b/projects/schizophrenia/src/VariantDetails/VariantDetails.js
@@ -11,27 +11,41 @@ import AnalysisGroupsTable from './AnalysisGroupsTable'
 const VariantContainer = styled.div`
   display: flex;
   flex-direction: column;
+  font-size: 16px;
   margin: 30px 50px 100px 0;
   min-height: 300px;
   width: 80%;
 `
 
-const SideBySide = styled.div`
-  align-items: space-between;
+const Column = styled.div``
+
+const Columns = styled.div`
   display: flex;
   flex-direction: row;
-  width: 100%;
-`
+  flex-wrap: wrap;
+  justify-content: space-between;
 
-const VariantDetails = styled.div`
-  width: 50%;
+  ${Column} {
+    flex-basis: calc(33% - 1em);
+  }
+
+  @media(max-width: 1024px) {
+    ${Column} {
+      flex-basis: calc(50% - 1em);
+    }
+  }
+
+  @media(max-width: 600px) {
+    ${Column} {
+      flex-basis: 100%;
+    }
+  }
 `
 
 const VariantAttributes = styled.div`
   align-items: space-between;
   display: flex;
   flex-direction: column;
-  font-size: 16px;
   margin: 10px 0;
 `
 
@@ -113,10 +127,9 @@ const Variant = ({ variant }) => {
   return (
     <VariantContainer>
       <h1>{variant.variant_id}</h1>
-      <SideBySide>
-        <VariantDetails>
-          <Link href={`http://gnomad.broadinstitute.org/variant/${variant.variant_id}`}>View in gnomAD</Link>
-
+      <Link href={`http://gnomad.broadinstitute.org/variant/${variant.variant_id}`}>View in gnomAD</Link>
+      <Columns>
+        <Column>
           <VariantAttributes>
             <h2>Statistics</h2>
             <VariantAttribute>
@@ -133,6 +146,29 @@ const Variant = ({ variant }) => {
             </VariantAttribute>
           </VariantAttributes>
 
+          {variant.pval_meta !== null && (
+            <VariantAttributes>
+              <h2>Analysis</h2>
+              <VariantAttribute>
+                <strong>Meta P-Value:</strong> {Number(variant.pval_meta.toPrecision(3)).toExponential()}
+              </VariantAttribute>
+              <VariantAttribute>
+                <strong>Estimate:</strong> {Number(variant.estimate.toPrecision(3)).toExponential()}
+              </VariantAttribute>
+              <VariantAttribute>
+                <strong>SE:</strong> {variant.se}
+              </VariantAttribute>
+              <VariantAttribute>
+                <strong>Qp:</strong> {variant.qp}
+              </VariantAttribute>
+              <VariantAttribute>
+                <strong>I2:</strong> {variant.i2}
+              </VariantAttribute>
+            </VariantAttributes>
+          )}
+        </Column>
+
+        <Column>
           <VariantAttributes>
             <h2>Annotations</h2>
             <VariantAttribute>
@@ -166,29 +202,10 @@ const Variant = ({ variant }) => {
               <strong>Comment:</strong> {variant.comment}
             </VariantAttribute>
           </VariantAttributes>
+        </Column>
 
-          {variant.pval_meta !== null && (
-            <VariantAttributes>
-              <h2>Analysis</h2>
-              <VariantAttribute>
-                <strong>Meta P-Value:</strong> {Number(variant.pval_meta.toPrecision(3)).toExponential()}
-              </VariantAttribute>
-              <VariantAttribute>
-                <strong>Estimate:</strong> {Number(variant.estimate.toPrecision(3)).toExponential()}
-              </VariantAttribute>
-              <VariantAttribute>
-                <strong>SE:</strong> {variant.se}
-              </VariantAttribute>
-              <VariantAttribute>
-                <strong>Qp:</strong> {variant.qp}
-              </VariantAttribute>
-              <VariantAttribute>
-                <strong>I2:</strong> {variant.i2}
-              </VariantAttribute>
-            </VariantAttributes>
-          )}
-
-          {variant.transcript_id && (
+        {variant.transcript_id && (
+          <Column>
             <VariantAttributes>
               <h2>Transcripts</h2>
               {variant.transcript_id.split(',').map(tID => (
@@ -205,12 +222,13 @@ const Variant = ({ variant }) => {
                 </VariantAttribute>
               ))}
             </VariantAttributes>
-          )}
-        </VariantDetails>
+          </Column>
+        )}
+      </Columns>
 
-        <AnalysisGroupsTable variantId={variant.variant_id} />
+      <h2>Analysis Groups</h2>
+      <AnalysisGroupsTable variantId={variant.variant_id} />
 
-      </SideBySide>
     </VariantContainer>
   )
 }

--- a/projects/schizophrenia/src/VariantDetails/VariantDetails.js
+++ b/projects/schizophrenia/src/VariantDetails/VariantDetails.js
@@ -1,45 +1,26 @@
-import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import React from 'react'
 import { connect } from 'react-redux'
-import gql from 'graphql-tag'
-import { graphql, compose } from 'react-apollo'
-import { singleVariantData, focusedVariant } from '@broad/redux-variants'
-import { fromJS } from 'immutable'
-import {
-  Table,
-  VerticalTextLabels,
-  TableVerticalLabel,
-  VerticalLabelText,
-  TableRows,
-  TableRow,
-  TableHeader,
-  TableCell,
-  TableTitleColumn,
-} from '@broad/ui'
+import styled from 'styled-components'
+
+import { singleVariantData } from '@broad/redux-variants'
+
+import AnalysisGroupsTable from './AnalysisGroupsTable'
+
 
 const VariantContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 80%;
+  margin: 30px 50px 100px 0;
   min-height: 300px;
-  ${'' /* margin-left: 50px; */}
-  margin-top: 30px;
-  margin-right: 50px;
-  margin-bottom: 100px;
+  width: 80%;
 `
 
 const SideBySide = styled.div`
+  align-items: space-between;
   display: flex;
   flex-direction: row;
   width: 100%;
-  align-items: space-between;
-
-  ${'' /* s: space-between; */}
-`
-
-const VariantTitle = styled.h1`
-
 `
 
 const VariantDetails = styled.div`
@@ -47,12 +28,11 @@ const VariantDetails = styled.div`
 `
 
 const VariantAttributes = styled.div`
-  display: flex;
-  font-size: 16px;
-  flex-direction: column;
   align-items: space-between;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  font-size: 16px;
+  margin: 10px 0;
 `
 
 const VariantAttribute = styled.div`
@@ -72,41 +52,6 @@ const Link = styled.a`
   text-decoration: none;
 `
 
-const schizophreniaVariantDetailQuery = gql`
-  query VariantDetailTable(
-    $variantQuery: String,
-  ) {
-    groups: schzGroups(variant_id: $variantQuery) {
-      pos
-      xpos
-      pval
-      ac_case
-      contig
-      beta
-      variant_id
-      an_ctrl
-      an_case
-      group
-      ac_ctrl
-      allele_freq
-    }
-  }
-`
-
-const withQuery = graphql(schizophreniaVariantDetailQuery, {
-  options: ({ variant }) => {
-    let variantQuery
-    if (!variant) {
-      variantQuery = ''
-    } else {
-      variantQuery = variant.variant_id
-    }
-    return ({
-      variables: { variantQuery },
-      errorPolicy: 'ignore'
-    })
-  },
-})
 
 function formatConsequence(abbreviation) {
   if (!abbreviation) {
@@ -144,14 +89,14 @@ function formatPolyPhen(abbreviation) {
   }
 }
 
-const Variant = ({ variant, data: { loading, groups } }) => {
-  if (!variant || loading) {
-    return <VariantContainer />
+const Variant = ({ variant }) => {
+  if (!variant) {
+    return null
   }
 
   const transcriptHGVSc = {}
   if (variant.hgvsc) {
-    variant.hgvsc.split(',').forEach(s => {
+    variant.hgvsc.split(',').forEach((s) => {
       const [tID, hgvsc] = s.split(':')
       transcriptHGVSc[tID] = hgvsc
     })
@@ -159,16 +104,15 @@ const Variant = ({ variant, data: { loading, groups } }) => {
 
   const transcriptHGVSp = {}
   if (variant.hgvsp) {
-    variant.hgvsp.split(',').forEach(s => {
+    variant.hgvsp.split(',').forEach((s) => {
       const [tID, hgvsp] = s.split(':')
       transcriptHGVSp[tID] = hgvsp
     })
   }
 
-  console.log(groups)
   return (
     <VariantContainer>
-      <VariantTitle>{variant.variant_id}</VariantTitle>
+      <h1>{variant.variant_id}</h1>
       <SideBySide>
         <VariantDetails>
           <Link href={`http://gnomad.broadinstitute.org/variant/${variant.variant_id}`}>View in gnomAD</Link>
@@ -264,38 +208,19 @@ const Variant = ({ variant, data: { loading, groups } }) => {
           )}
         </VariantDetails>
 
-        <div>
-          <h2>Groups</h2>
-          <Table>
-            <TableRows>
-              <TableHeader>
-                <TableCell width={'200px'}>Group</TableCell>
-                <TableCell width={'80px'}>Cases</TableCell>
-                <TableCell width={'80px'}>Controls</TableCell>
-                <TableCell width={'80px'}>P-value</TableCell>
-                <TableCell width={'80px'}>Beta</TableCell>
-              </TableHeader>
-              {fromJS(groups).map(group => (
-                <TableRow key={group.get('group')}>
-                  <TableCell width={'200px'}>{group.get('group')}</TableCell>
-                  <TableCell width={'80px'}>{group.get('ac_case')}</TableCell>
-                  <TableCell width={'80px'}>{group.get('ac_ctrl')}</TableCell>
-                  <TableCell width={'80px'}>{group.get('pval')}</TableCell>
-                  <TableCell width={'80px'}>{group.get('beta')}</TableCell>
-                </TableRow>
-              ))}
-            </TableRows>
-          </Table>
-        </div>
+        <AnalysisGroupsTable variantId={variant.variant_id} />
+
       </SideBySide>
     </VariantContainer>
   )
 }
+
 Variant.propTypes = {
-  variant: PropTypes.object.isRequired,
+  variant: PropTypes.object,
 }
 
-export default compose(
-  connect(state => ({ variant: singleVariantData(state) })),
-  withQuery
-)(Variant)
+Variant.defaultProps = {
+  variant: null,
+}
+
+export default connect(state => ({ variant: singleVariantData(state) }))(Variant)

--- a/projects/schizophrenia/src/VariantDetails/index.js
+++ b/projects/schizophrenia/src/VariantDetails/index.js
@@ -1,0 +1,1 @@
+export { default } from './VariantDetails'


### PR DESCRIPTION
Before
<img width="1404" alt="screen shot 2018-06-08 at 11 25 54 am" src="https://user-images.githubusercontent.com/1156625/41166890-60aa57e8-6b0f-11e8-9207-3c4b0ee2fc05.png">

After
<img width="1437" alt="screen shot 2018-06-08 at 11 25 16 am" src="https://user-images.githubusercontent.com/1156625/41166895-6355d3e6-6b0f-11e8-8984-19fc415339d3.png">

The layout change makes room for additional allele frequency columns in the analysis groups table

Also,
* Isolate the graphql wrapper to the analysis groups table, so that the other variant information can be viewed while the analysis groups are loading
* More consistent font sizes within the variant details section
* More semantically appropriate elements (`dl`, `dt`, and `dd`) for listing variant attributes