### PR TITLE
Return all ClinVar variants instead of only first page

### DIFF
--- a/packages/api/src/schema/types/gene.js
+++ b/packages/api/src/schema/types/gene.js
@@ -172,7 +172,7 @@ const geneType = new GraphQLObjectType({
     clinvar_variants: {
       type: new GraphQLList(clinvarType),
       resolve: (obj, args, ctx) =>
-        lookupClinvarVariantsByGeneName(ctx.database.elastic, 'clinvar', obj.gene_name),
+        lookupClinvarVariantsByGeneName(ctx.database.elastic, obj.gene_name),
     },
     transcript: {
       type: transcriptType,

--- a/packages/api/src/utilities/elasticsearch.js
+++ b/packages/api/src/utilities/elasticsearch.js
@@ -1,0 +1,47 @@
+/**
+ * Search and then scroll to retrieve all pages of search results.
+ *
+ * @param {elasticsearch.Client} esClient Elasticsearch client
+ * @param {Object} searchParams Argument to elasticsearch.Client#search
+ * @return {Object[]} Search results
+ */
+export async function fetchAllSearchResults(esClient, searchParams) {
+  let allResults = []
+  const responseQueue = []
+
+  const size = searchParams.size || 1000
+  const scroll = searchParams.scroll || '30s'
+
+  responseQueue.push(
+    await esClient.search({
+      ...searchParams,
+      scroll,
+      size,
+    })
+  )
+
+  while (responseQueue.length) {
+    const response = responseQueue.shift()
+    const pageResults = response.hits.hits.map(doc => doc._source)
+
+    allResults = allResults.concat(pageResults)
+
+    if (allResults.length === response.hits.total) {
+      // eslint-disable-next-line no-await-in-loop
+      await esClient.clearScroll({
+        scrollId: response._scroll_id,
+      })
+      break
+    }
+
+    responseQueue.push(
+      // eslint-disable-next-line no-await-in-loop
+      await esClient.scroll({
+        scroll,
+        scrollId: response._scroll_id,
+      })
+    )
+  }
+
+  return allResults
+}


### PR DESCRIPTION
Currently, `lookupClinvarVariantsByGeneName` returns only the first page of results from Elasticsearch. However, some genes (ex. BRCA1) have more than 1000 ClinVar variants.

This changes `lookupClinvarVariantsByGeneName` to use Elasticsearch's [scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/search-request-scroll.html) to retrieve all pages of results.