### PR TITLE
Correct "start lost" consequence label

### DIFF
--- a/packages/table/src/Table.js
+++ b/packages/table/src/Table.js
@@ -234,7 +234,7 @@ const consequencePresentation = {
   frameshift_variant: { name: 'frameshift', color: lof },
   stop_gained: { name: 'stop gained', color: lof },
   stop_lost: { name: 'stop lost', color: lof },
-  start_lost: { name: 'stop lost', color: lof },
+  start_lost: { name: 'start lost', color: lof },
   lof: { name: 'loss of function', color: lof },
 }
 


### PR DESCRIPTION
Currently, both "stop_lost" and "start_lost" consequences are labeled as "stop lost".

Resolves #55.