### PR TITLE
Prevent transcript fan out from moving region viewer

### DIFF
--- a/packages/region/src/RegionViewer.js
+++ b/packages/region/src/RegionViewer.js
@@ -12,13 +12,8 @@ import {
 const RegionViewerWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding-left: 10px;
-  padding-bottom: 10px;
-`
-
-const RegionArea = styled.div`
-  flex-direction: column;
+  margin: 0 auto 10px;
+  width: ${props => props.width}px;
 `
 
 const exonColor = '#212121'
@@ -154,10 +149,8 @@ class RegionViewer extends Component {
     }
 
     return (
-      <RegionViewerWrapper>
-        <RegionArea width={width + leftPanelWidth + rightPanelWidth}>
-          {this.renderChildren(childProps)}
-        </RegionArea>
+      <RegionViewerWrapper width={width + leftPanelWidth + rightPanelWidth}>
+        {this.renderChildren(childProps)}
       </RegionViewerWrapper>
     )
   }

--- a/packages/region/src/RegionViewer.js
+++ b/packages/region/src/RegionViewer.js
@@ -7,7 +7,8 @@ import {
   calculatePositionOffset,
   invertPositionOffset,
   calculateXScale,
-} from '@broad/utilities/src/coordinates'  // eslint-disable-line
+} from '@broad/utilities/src/coordinates'
+
 
 const RegionViewerWrapper = styled.div`
   display: flex;
@@ -30,7 +31,6 @@ class RegionViewer extends Component {
     leftPanelWidth: PropTypes.number.isRequired,
     rightPanelWidth: PropTypes.number.isRequired,
     exonSubset: PropTypes.array,
-    broadcast: PropTypes.func,
     featuresToDisplay: PropTypes.array,
   }
 
@@ -38,8 +38,6 @@ class RegionViewer extends Component {
     exonSubset: null,
     leftPanelWidth: 100,
     rightPanelWidth: 150,
-    onRegionClick: () => {},
-    broadcast: () => {},
     featuresToDisplay: ['CDS'],
     regionAttributes: {
       CDS: {
@@ -65,43 +63,7 @@ class RegionViewer extends Component {
     },
   }
 
-  state = {
-    rightPanelWidth: 150,
-    ready: false,
-  }
-
-  // componentWillMount () {
-  //   this.broadcastOffsetRegions()
-  // }
-  //
-  // componentDidUpdate () {
-  //   this.broadcastOffsetRegions()
-  // }
-
-  setWidth = (event, newValue) => {
-    const newWidth = 800 * newValue
-    this.setState({ width: newWidth })
-  }
-
-  setLeftPanelWidth = (event, newValue) => {
-    const leftPanelWidth = Math.floor(400 * newValue)
-    this.setState({ leftPanelWidth })
-  }
-
-  broadcastOffsetRegions = () => {
-    if (this.props.regions) {
-      const offsetRegions = calculateOffsetRegions(
-        this.props.featuresToDisplay,
-        this.props.regionAttributes,
-        this.props.padding,
-        this.props.regions,
-        this.props.exonSubset
-      )
-      this.props.broadcast({ offsetRegions })
-    }
-  }
-
-  renderChildren = (childProps) => {
+  renderChildren(childProps) {
     // eslint-disable-next-line
     return React.Children.map(this.props.children, (child) => {
       if (child) {
@@ -111,8 +73,8 @@ class RegionViewer extends Component {
   }
 
   render() {
-    const { featuresToDisplay } = this.props
     const {
+      featuresToDisplay,
       regions,
       regionAttributes,
       width,

--- a/packages/region/src/RegionViewer.js
+++ b/packages/region/src/RegionViewer.js
@@ -37,7 +37,7 @@ class RegionViewer extends Component {
   static defaultProps = {
     exonSubset: null,
     leftPanelWidth: 100,
-    rightPanelWidth: 150,
+    rightPanelWidth: 160,
     featuresToDisplay: ['CDS'],
     regionAttributes: {
       CDS: {

--- a/packages/track-transcript/src/TranscriptConnected.js
+++ b/packages/track-transcript/src/TranscriptConnected.js
@@ -1,7 +1,5 @@
-import React from 'react'
-import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { TranscriptTrack } from './index'
+import { bindActionCreators } from 'redux'
 
 import {
   currentGene,
@@ -17,69 +15,10 @@ import {
   actions as geneActions,
 } from '@broad/redux-genes'
 
-const TranscriptConnected = ({
-  ownProps,
-  transcripts,
-  currentTranscript,
-  canonicalTranscript,
-  transcriptsGrouped,
-  setCurrentTranscript,
-  currentExon,
-  setCurrentExon,
-  currentTissue,
-  setCurrentTissue,
-  tissueStats,
-  strand,
-  currentGene,
-  transcriptFanOut,
-  toggleTranscriptFanOut,
-}) => {
-  return (
-    <TranscriptTrack
-      transcripts={transcripts}
-      currentTranscript={currentTranscript}
-      transcriptsGrouped={transcriptsGrouped}
-      onTranscriptNameClick={setCurrentTranscript}
-      currentExon={currentExon}
-      onExonClick={setCurrentExon}
-      currentTissue={currentTissue}
-      tissueStats={tissueStats}
-      onTissueChange={setCurrentTissue}
-      currentGene={currentGene}
-      canonicalTranscript={canonicalTranscript}
-      strand={strand}
-      transcriptFanOut={transcriptFanOut}
-      transcriptButtonOnClick={toggleTranscriptFanOut}
-      {...ownProps}
-    />
-  )
-}
-TranscriptConnected.propTypes = {
-  ownProps: PropTypes.object.isRequired,
-  currentGene: PropTypes.string,
-  currentTissue: PropTypes.string,
-  currentTranscript: PropTypes.string,
-  canonicalTranscript: PropTypes.string,
-  currentExon: PropTypes.string,
-  strand: PropTypes.string,
-  transcripts: PropTypes.array.isRequired,
-  transcriptsGrouped: PropTypes.object.isRequired,
-  tissueStats: PropTypes.any.isRequired,
-  setCurrentTissue: PropTypes.func.isRequired,
-  setCurrentTranscript: PropTypes.func.isRequired,
-  setCurrentExon: PropTypes.func.isRequired,
-}
+import TranscriptTrack from './TranscriptTrack'
 
-TranscriptConnected.defaultProps = {
-  currentTissue: null,
-  currentTranscript: null,
-  canonicalTranscript: null,
-  currentExon: null,
-  strand: null,
-}
 
-const mapStateToProps = (state, ownProps) => ({
-  ownProps,
+const mapStateToProps = state => ({
   currentGene: currentGene(state),
   currentTissue: currentTissue(state),
   currentTranscript: currentTranscript(state),
@@ -92,4 +31,11 @@ const mapStateToProps = (state, ownProps) => ({
   strand: strand(state),
 })
 
-export default connect(mapStateToProps, geneActions)(TranscriptConnected)
+const mapDispatchToProps = dispatch => ({
+  onExonClick: bindActionCreators(geneActions.setCurrentExon, dispatch),
+  onTissueChange: bindActionCreators(geneActions.setCurrentTissue, dispatch),
+  onTranscriptNameClick: bindActionCreators(geneActions.setCurrentTranscript, dispatch),
+  transcriptButtonOnClick: bindActionCreators(geneActions.toggleTranscriptFanOut, dispatch),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(TranscriptTrack)

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -96,35 +96,22 @@ const GtexTitleWrapper = styled.div`
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   width: 100%;
   height: 70%;
-  font-size: 14px;
   padding-left: 10px;
 `
 
-const GtexPlotWrapper = styled.div`
-  ${'' /* margin-bottom: 5px; */}
-`
+const GtexPlotWrapper = styled.div``
 
 const GtexTitleText = styled.a`
   font-size: 13px;
-  font-weight: normal;
-  line-height: 8px;
   margin-bottom: 5px;
-  margin-top: 0;
-  margin-left: 6px;
-  flex-shrink: 0;
   text-decoration: none;
   color: #428bca;
 `
 const GtexTissueSelect = styled.select`
   max-width: 100%;
-  ${'' /* height: 100%; */}
   font-size: 12px;
-  margin-bottom: 0;
-  margin-top: 0;
-  flex-shrink: 0;
 `
 
 const TranscriptRightPanel = ({

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -93,6 +93,7 @@ const TranscriptName = styled.div`
 `
 
 const GtexTitleWrapper = styled.div`
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -482,7 +482,6 @@ TranscriptGroup.propTypes = {
 const TranscriptTrackContainer = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
   /*border: 1px solid orange;*/
 `
 

--- a/projects/gnomad/src/GenePage/RegionViewer.js
+++ b/projects/gnomad/src/GenePage/RegionViewer.js
@@ -13,9 +13,7 @@ import { screenSize, SectionTitle } from '@broad/ui'
 import {
   geneData,
   regionalConstraint,
-  transcriptFanOut,
   exonPadding,
-  actions as geneActions,
 } from '@broad/redux-genes'
 
 import {
@@ -73,8 +71,6 @@ const GeneViewer = ({
   exonPadding,
   regionalConstraint,
   screenSize,
-  transcriptFanOut,
-  toggleTranscriptFanOut,
   variantFilter,
 }) => {
   const smallScreen = screenSize.width < 900
@@ -229,8 +225,6 @@ const GeneViewer = ({
         <TranscriptTrackConnected
           height={12}
           showRightPanel={!smallScreen}
-          transcriptFanOut={transcriptFanOut}
-          transcriptButtonOnClick={toggleTranscriptFanOut}
         />
         {regionalConstraint.length > 0 && selectedVariantDataset === 'exacVariants' &&
           <RegionalConstraintTrack
@@ -262,8 +256,6 @@ GeneViewer.propTypes = {
   variantFilter: PropTypes.string.isRequired,
   regionalConstraint: PropTypes.array.isRequired,
   screenSize: PropTypes.object.isRequired,
-  transcriptFanOut: PropTypes.bool.isRequired,
-  toggleTranscriptFanOut: PropTypes.func.isRequired,
 }
 export default connect(
   state => ({
@@ -273,12 +265,6 @@ export default connect(
     selectedVariantDataset: selectedVariantDataset(state),
     regionalConstraint: regionalConstraint(state),
     screenSize: screenSize(state),
-    transcriptFanOut: transcriptFanOut(state),
     variantFilter: variantFilter(state),
-  }),
-  dispatch => ({
-    // setRegionViewerAttributes: regionViewerAttributes =>
-    //   dispatch(activeActions.setRegionViewerAttributes(regionViewerAttributes)),
-    toggleTranscriptFanOut: () => dispatch(geneActions.toggleTranscriptFanOut()),
   })
 )(GeneViewer)

--- a/projects/gnomad/src/GenePage/RegionViewer.js
+++ b/projects/gnomad/src/GenePage/RegionViewer.js
@@ -212,7 +212,6 @@ const GeneViewer = ({
         padding={exonPadding}
         regions={canonicalExons}
         regionAttributes={attributeConfig}
-        // broadcast={setRegionViewerAttributes}
       >
         <CoverageTrack
           title={'Coverage'}
@@ -251,7 +250,6 @@ GeneViewer.propTypes = {
   gene: PropTypes.object.isRequired,
   allVariants: PropTypes.any.isRequired,
   exonPadding: PropTypes.number.isRequired,
-  // setRegionViewerAttributes: PropTypes.func.isRequired,
   selectedVariantDataset: PropTypes.string.isRequired,
   variantFilter: PropTypes.string.isRequired,
   regionalConstraint: PropTypes.array.isRequired,

--- a/projects/schizophrenia/src/ExomePage/RegionViewer.js
+++ b/projects/schizophrenia/src/ExomePage/RegionViewer.js
@@ -24,8 +24,6 @@ import { actions as tableActions } from '@broad/table'
 import {
   geneData,
   exonPadding,
-  transcriptFanOut,
-  actions as geneActions
 } from '@broad/redux-genes'
 
 import {
@@ -84,8 +82,6 @@ class SchizophreniaGeneViewer extends PureComponent {
       visibleVariants,
       exonPadding,
       screenSize,
-      transcriptFanOut,
-      toggleTranscriptFanOut,
       variantFilter,
       allVariantsInCurrentDataset,
       focusedVariant,
@@ -144,8 +140,6 @@ class SchizophreniaGeneViewer extends PureComponent {
           <TranscriptTrackConnected
             height={12}
             showRightPanel={!smallScreen}
-            transcriptFanOut={transcriptFanOut}
-            transcriptButtonOnClick={toggleTranscriptFanOut}
           />
           <VariantTrack
             key={'cases'}
@@ -173,8 +167,6 @@ SchizophreniaGeneViewer.propTypes = {
   exonPadding: PropTypes.number.isRequired,
   variantFilter: PropTypes.string.isRequired,
   screenSize: PropTypes.object.isRequired,
-  transcriptFanOut: PropTypes.bool.isRequired,
-  toggleTranscriptFanOut: PropTypes.func.isRequired,
 }
 export default connect(
   state => ({
@@ -182,15 +174,12 @@ export default connect(
     exonPadding: exonPadding(state),
     visibleVariants: finalFilteredVariants(state),
     screenSize: screenSize(state),
-    transcriptFanOut: transcriptFanOut(state),
     variantFilter: variantFilter(state),
     focusedVariant: focusedVariant(state),
     allVariantsInCurrentDataset: allVariantsInCurrentDataset(state),
   }),
   dispatch => ({
-    toggleTranscriptFanOut: () => dispatch(geneActions.toggleTranscriptFanOut()),
     setFocusedVariant: variantId => dispatch(variantActions.setFocusedVariant(variantId)),
     setCurrentTableScrollData: data => dispatch(tableActions.setCurrentTableScrollData(data))
-
   })
 )(SchizophreniaGeneViewer)

--- a/projects/variantfx/src/GenePage/RegionViewer.js
+++ b/projects/variantfx/src/GenePage/RegionViewer.js
@@ -22,8 +22,6 @@ import { screenSize } from '@broad/ui'
 import {
   geneData,
   exonPadding,
-  transcriptFanOut,
-  actions as geneActions
 } from '@broad/redux-genes'
 
 import {
@@ -62,8 +60,6 @@ const GeneRegion = ({
   visibleVariants,
   exonPadding,
   screenSize,
-  transcriptFanOut,
-  toggleTranscriptFanOut,
 }) => {
   const smallScreen = screenSize.width < 900
   const regionViewerWidth = smallScreen ? screenSize.width - 150 : screenSize.width - 330
@@ -106,8 +102,6 @@ const GeneRegion = ({
         <TranscriptTrackConnected
           height={12}
           showRightPanel={!smallScreen}
-          transcriptFanOut={transcriptFanOut}
-          transcriptButtonOnClick={toggleTranscriptFanOut}
         />
         {allTrack}
         <NavigatorTrackConnected noVariants />
@@ -120,8 +114,6 @@ GeneRegion.propTypes = {
   visibleVariants: PropTypes.any.isRequired,
   exonPadding: PropTypes.number.isRequired,
   screenSize: PropTypes.object.isRequired,
-  transcriptFanOut: PropTypes.bool.isRequired,
-  toggleTranscriptFanOut: PropTypes.func.isRequired,
 }
 export default connect(
   state => ({
@@ -129,9 +121,5 @@ export default connect(
     exonPadding: exonPadding(state),
     visibleVariants: finalFilteredVariants(state),
     screenSize: screenSize(state),
-    transcriptFanOut: transcriptFanOut(state),
-  }),
-  dispatch => ({
-    toggleTranscriptFanOut: () => dispatch(geneActions.toggleTranscriptFanOut()),
   })
 )(GeneRegion)


### PR DESCRIPTION
Currently, when the list of alternate transcripts is closed, the entire region viewer with all of the tracks shifts to the right. This is confusing because it appears as though more content is changing than just the transcript track.

## Before
<img width="1792" alt="screen shot 2018-06-15 at 4 52 14 pm" src="https://user-images.githubusercontent.com/1156625/41493084-c03cdac4-70d1-11e8-873a-163cf795d304.png">
<img width="1792" alt="screen shot 2018-06-15 at 4 52 17 pm" src="https://user-images.githubusercontent.com/1156625/41493085-c04a6b44-70d1-11e8-96ed-b38a91bd7c80.png">

## After
<img width="1792" alt="screen shot 2018-06-15 at 7 16 25 pm" src="https://user-images.githubusercontent.com/1156625/41493086-c055f0a4-70d1-11e8-8512-3877682657e1.png">
<img width="1792" alt="screen shot 2018-06-15 at 7 16 29 pm" src="https://user-images.githubusercontent.com/1156625/41493087-c066d900-70d1-11e8-8e1d-5a10be760def.png">
