### PR TITLE
Use position for x axis in Manhattan plot

### DIFF
--- a/packages/manhattan/src/example/index.js
+++ b/packages/manhattan/src/example/index.js
@@ -1,12 +1,16 @@
 import React from 'react'
-import ManhattanPlot from '../index'
 
 import data from '@resources/gwas-eg.json'  // eslint-disable-line
+
+import ManhattanPlot from '../index'
+
+
+const plotData = data.map(d => ({ ...d, chromosome: `${d.chromosome}` }))
 
 const ManhattanPlotExample = () => {
   return (
     <div>
-      <ManhattanPlot data={data} onClickPoint={console.log} />
+      <ManhattanPlot data={plotData} onClickPoint={console.log} />
     </div>
   )
 }

--- a/packages/manhattan/src/example/index.js
+++ b/packages/manhattan/src/example/index.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 import ManhattanPlot from '../index'
 
 import data from '@resources/gwas-eg.json'  // eslint-disable-line
@@ -6,7 +6,7 @@ import data from '@resources/gwas-eg.json'  // eslint-disable-line
 const ManhattanPlotExample = () => {
   return (
     <div>
-      <ManhattanPlot data={data} />
+      <ManhattanPlot data={data} onClickPoint={console.log} />
     </div>
   )
 }

--- a/packages/manhattan/src/index.js
+++ b/packages/manhattan/src/index.js
@@ -37,8 +37,9 @@ const ManhattanPlot = ({
 
   const yExtent = extent(data, d => d['-log10p'])
   const yScale = scaleLinear()
-    .domain([yExtent[0], yExtent[1] * 1.1])
+    .domain(yExtent)
     .range([height - padding, 10])
+    .nice()
 
   const titleText = (
     <text

--- a/packages/manhattan/src/index.js
+++ b/packages/manhattan/src/index.js
@@ -29,7 +29,7 @@ const ManhattanPlot = ({
 
   const plotChromosomes = includeSexChromosomes ? HUMAN_CHROMOSOMES : HUMAN_AUTOSOMES
   const chromosomeColors = plotChromosomes.reduce((acc, chr) =>
-    ({ ...acc, [chr.replace('chr', '')]: randomColor() }), {})
+    ({ ...acc, [chr]: randomColor() }), {})
 
   const xScale = scaleLinear()
     .domain([0, data.length])
@@ -105,7 +105,7 @@ const ManhattanPlot = ({
 
   const chromosomeXPos = {}
   plotChromosomes.reduce((acc, chromosome) => {
-    const snpsForChromosome = snpsPerChromosome[chromosome.replace('chr', '')]
+    const snpsForChromosome = snpsPerChromosome[chromosome]
     chromosomeXPos[chromosome] = xScale((acc + (snpsForChromosome / 2)))
     return acc + snpsForChromosome
   }, 0)
@@ -120,7 +120,7 @@ const ManhattanPlot = ({
           x={chromosomeXPos[chr]}
           y={(height - padding) + 20}
         >
-          {chr.replace('chr', '')}
+          {chr}
         </text>
       ))}
     </g>
@@ -161,7 +161,7 @@ const ManhattanPlot = ({
 ManhattanPlot.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape({
     snp: PropTypes.string.isRequired,
-    chromosome: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 'X', 'Y']).isRequired,
+    chromosome: PropTypes.oneOf(HUMAN_CHROMOSOMES).isRequired,
     pos: PropTypes.number.isRequired,
     '-log10p': PropTypes.number.isRequired,
   })).isRequired,

--- a/packages/manhattan/src/index.js
+++ b/packages/manhattan/src/index.js
@@ -19,10 +19,11 @@ function randomColor() {
 
 const ManhattanPlot = ({
   data,
-  title,
-  width,
   height,
   includeSexChromosomes,
+  onClickPoint,
+  title,
+  width,
 }) => {
   const padding = 60
 
@@ -124,16 +125,20 @@ const ManhattanPlot = ({
     </g>
   )
 
+  const clickHandler = e => onClickPoint(e.target.getAttribute('data-id'))
+
   const snps = data.map((snp, i) => {
     const color = chromosomeColors[snp.chromosome]
     return (
       <circle
         key={snp.snp}
+        data-id={snp.snp}
         cx={xScale(i)}
         cy={yScale(snp['-log10p'])}
         r={2}
         fill={color}
         stroke={'black'}
+        onClick={clickHandler}
       />
     )
   })
@@ -161,6 +166,7 @@ ManhattanPlot.propTypes = {
   })).isRequired,
   height: PropTypes.number,
   includeSexChromosomes: PropTypes.bool,
+  onClickPoint: PropTypes.func,
   title: PropTypes.string,
   width: PropTypes.number,
 }
@@ -168,6 +174,7 @@ ManhattanPlot.propTypes = {
 ManhattanPlot.defaultProps = {
   height: 500,
   includeSexChromosomes: false,
+  onClickPoint: () => {},
   title: '',
   width: 900,
 }

--- a/packages/manhattan/src/index.js
+++ b/packages/manhattan/src/index.js
@@ -23,7 +23,6 @@ const ManhattanPlot = ({
   width,
   height,
   includeSexChromosomes,
-  showAxisBounds,
 }) => {
   const padding = 60
 
@@ -39,39 +38,6 @@ const ManhattanPlot = ({
   const yScale = scaleLinear()
     .domain([yExtent[0], yExtent[1] * 1.1])
     .range([height - padding, 10])
-
-  const background = (
-    <rect
-      x={0}
-      y={0}
-      width={width}
-      height={height}
-      fill={'none'}
-      stroke={'black'}
-    />
-  )
-
-  const yAxisBackground = (
-    <rect
-      x={0}
-      y={0}
-      width={padding}
-      height={height}
-      fill={'white'}
-      stroke={'black'}
-    />
-  )
-
-  const xAxisBackground = (
-    <rect
-      x={0}
-      y={height - padding}
-      width={width}
-      height={padding}
-      fill={'none'}
-      stroke={'black'}
-    />
-  )
 
   const titleText = (
     <text
@@ -175,13 +141,6 @@ const ManhattanPlot = ({
   return (
     <div>
       <svg width={width} height={height}>
-        {showAxisBounds && (
-          <g>
-            {background}
-            {yAxisBackground}
-            {xAxisBackground}
-          </g>
-        )}
         {titleText}
         {yAxisLabel}
         {yAxisTicks}
@@ -202,7 +161,6 @@ ManhattanPlot.propTypes = {
   })).isRequired,
   height: PropTypes.number,
   includeSexChromosomes: PropTypes.bool,
-  showAxisBounds: PropTypes.bool,
   title: PropTypes.string,
   width: PropTypes.number,
 }
@@ -210,7 +168,6 @@ ManhattanPlot.propTypes = {
 ManhattanPlot.defaultProps = {
   height: 500,
   includeSexChromosomes: false,
-  showAxisBounds: false,
   title: '',
   width: 900,
 }

--- a/packages/utilities/src/constants/chromosomes.js
+++ b/packages/utilities/src/constants/chromosomes.js
@@ -1,5 +1,5 @@
-export const HUMAN_AUTOSOMES = Array.from(new Array(22), (x, i) => `chr${i + 1}`)
+export const HUMAN_AUTOSOMES = Array.from(new Array(22), (x, i) => `${i + 1}`)
 
-export const HUMAN_CHROMOSOMES = [...HUMAN_AUTOSOMES, 'chrX', 'chrY']
+export const HUMAN_CHROMOSOMES = [...HUMAN_AUTOSOMES, 'X', 'Y']
 
-export const HUMAN_CHROMOSOMES_WITH_MITO = [ ...HUMAN_CHROMOSOMES, 'chrM']
+export const HUMAN_CHROMOSOMES_WITH_MITO = [...HUMAN_CHROMOSOMES, 'M']


### PR DESCRIPTION
Previously, all data points on the Manhattan plot were evenly spaced along the x axis despite some data points being at the same position in the genome.

For example, when plotting `resources/schizophrenia-manhattan.json`:

Before

<img width="1020" alt="before" src="https://user-images.githubusercontent.com/1156625/41540297-e2289534-72dd-11e8-8bfe-783de74aebb1.png">

After

<img width="1014" alt="after" src="https://user-images.githubusercontent.com/1156625/41540298-e236bbaa-72dd-11e8-8c4e-64c86f08a97f.png">
