### PR TITLE
Remove withRouter from VariantTable

### DIFF
--- a/packages/table/src/VariantTable.js
+++ b/packages/table/src/VariantTable.js
@@ -37,7 +37,6 @@ const VariantTable = ({
   title,
   height,
   tableConfig,
-  history,
   screenSize,
   filteredIdList,
 }) => {
@@ -78,7 +77,6 @@ VariantTable.propTypes = {
   title: PropTypes.string,
   height: PropTypes.number,
   tableConfig: PropTypes.func.isRequired,
-  history: PropTypes.object.isRequired,
   screenSize: PropTypes.object.isRequired,
   filteredIdList: PropTypes.any.isRequired,
   // setVisibleInTable: PropTypes.func.isRequired,

--- a/projects/gnomad/src/GenePage/index.js
+++ b/projects/gnomad/src/GenePage/index.js
@@ -53,8 +53,6 @@ const BottomButtonSection = styled.div`
   margin-top: 20px;
 `
 
-const VariantTableWithRouter = withRouter(VariantTable)
-
 // const loading_gifs = [
 //   'http://www.skirlrecords.com/sites/all/themes/valx/imgs/loading.gif',
 //   'https://thumbs.gfycat.com/ClearcutGoldenKittiwake-size_restricted.gif',
@@ -92,16 +90,7 @@ const GenePageConnected = ({
         <Route
           exact
           path="/gene/:gene"
-          render={() => {
-            return (
-              <div>
-                <VariantTableWithRouter
-                  tableConfig={tableConfig}
-                />
-              </div>
-
-            )
-          }}
+          render={() => <VariantTable tableConfig={tableConfig} />}
         />
         <BottomButtonSection>
           <ClassicExacButton onClick={exportVariantsToCsv}>

--- a/projects/gnomad/src/RegionPage/index.js
+++ b/projects/gnomad/src/RegionPage/index.js
@@ -61,7 +61,6 @@ const TableSection = styled.div`
     margin-top: 10px;
   }
 `
-const VariantTableWithRouter = withRouter(VariantTable)
 
 const RegionPage = ({
   regionData,
@@ -81,14 +80,7 @@ const RegionPage = ({
         <Route
           exact
           path="/region/:regionId"
-          render={() => {
-            return (
-              <VariantTableWithRouter
-                tableConfig={tableConfig}
-                height={400}
-              />
-            )
-          }}
+          render={() => <VariantTable tableConfig={tableConfig} />}
         />
       </TableSection>
     </RegionPageWrapper>

--- a/projects/schizophrenia/src/ExomePage/index.js
+++ b/projects/schizophrenia/src/ExomePage/index.js
@@ -26,7 +26,6 @@ import RegionViewer from './RegionViewer'
 import tableConfig from './tableConfig'
 import { fetchSchz } from './fetch'
 
-const VariantTableWithRouter = withRouter(VariantTable)
 
 const MainPage = ({
   gene,
@@ -51,14 +50,7 @@ const MainPage = ({
       <Route
         exact
         path="/gene/:gene"
-        render={() => {
-          return (
-            <VariantTableWithRouter
-              tableConfig={tableConfig}
-              height={600}
-            />
-          )
-        }}
+        render={() => <VariantTable tableConfig={tableConfig} />}
       />
       <VariantDetails />
     </GenePage>

--- a/projects/schizophrenia/src/GwasPage/index.js
+++ b/projects/schizophrenia/src/GwasPage/index.js
@@ -25,7 +25,6 @@ import RegionViewer from './RegionViewer'
 import tableConfig from './tableConfig'
 import { fetchRegion } from './fetch'
 
-const VariantTableWithRouter = withRouter(VariantTable)
 
 const RegionPage = ({
   regionData,
@@ -45,14 +44,7 @@ const RegionPage = ({
         <Route
           exact
           path="/region/:regionId"
-          render={() => {
-            return (
-              <VariantTableWithRouter
-                tableConfig={tableConfig}
-                height={400}
-              />
-            )
-          }}
+          render={() => <VariantTable tableConfig={tableConfig} />}
         />
       </TableSection>
     </GenePage>

--- a/projects/variantfx/src/GenePage/index.js
+++ b/projects/variantfx/src/GenePage/index.js
@@ -29,7 +29,6 @@ import RegionViewer from './RegionViewer'
 import tableConfig from './tableConfig'
 import fetchFunction from './fetch'
 
-const VariantTableWithRouter = withRouter(VariantTable)
 
 const SectionTitleIndent = SectionTitle.extend`
   margin-left: 70px;
@@ -74,17 +73,7 @@ const Page = ({
         <Route
           exact
           path="/gene/:gene"
-          render={() => {
-            return (
-              <div>
-                <VariantTableWithRouter
-                  tableConfig={tableConfig}
-                  height={600}
-                />
-                {/* <VariantPage /> */}
-              </div>
-            )
-          }}
+          render={() => <VariantTable tableConfig={tableConfig} />}
         />
       </TableSection>
     </GenePage>


### PR DESCRIPTION
After #72, VariantTable no longer uses its `history` prop and thus does not need to be wrapped in the `withRouter` higher order component.

Also, the `height` prop passed to Table is also hard coded inside the VariantTable component, so there's no use in passing VariantTable a `height` prop.