### PR TITLE
Fix table row rendering for rows that have not yet loaded

### DIFF
--- a/packages/table/src/VariantTable.js
+++ b/packages/table/src/VariantTable.js
@@ -55,7 +55,6 @@ const VariantTable = ({
         remoteRowCount={variants.size}
         loadMoreRows={() => {}}
         overscan={5}
-        loadLookAhead={0}
         onRowClick={setFocusedVariant}
         onRowHover={setHoveredVariant}
         scrollToRow={tablePosition}

--- a/packages/table/src/VariantTableApollo.js
+++ b/packages/table/src/VariantTableApollo.js
@@ -196,7 +196,6 @@ const VariantTable = ({
         remoteRowCount={variantResult.count}
         loadMoreRows={loadMoreVariants}
         overscan={5}
-        loadLookAhead={25}
         onRowClick={() => {}}
         onRowHover={() => {}}
         // scrollToRow={tablePosition}

--- a/packages/table/src/example/ScrollFetch.example.js
+++ b/packages/table/src/example/ScrollFetch.example.js
@@ -582,7 +582,6 @@ class InfiniteTableExample extends Component {
           remoteRowCount={this.state.totalVariantCount}
           loadMoreRows={this.fetchMoreData}
           overscan={60}
-          loadLookAhead={1000}
           showIndex
         />
       </div>

--- a/projects/schizophrenia/src/GeneResults.js
+++ b/projects/schizophrenia/src/GeneResults.js
@@ -170,7 +170,6 @@ class SchizophreniaGeneResults extends PureComponent {
             remoteRowCount={sortedData.size}
             loadMoreRows={() => {}}
             overscan={5}
-            loadLookAhead={0}
             onRowClick={this.geneOnClick}
             onRowHover={() => {}}
             onScroll={() => {}}


### PR DESCRIPTION
Currently, in the example code using Apollo for populating the variant table, scrolling fast enough will result in an error:

```
Uncaught TypeError: Cannot read property 'variant_id' of undefined
    at getDataCell (Table.js:312)
    at Table.js:455
    at Array.map (<anonymous>)
    at getDataRow (Table.js:454)
    at Table.js:551
    at List._this._cellRenderer (List.js:82)
    at defaultCellRangeRenderer (defaultCellRangeRenderer.js:99)
    at Grid._calculateChildrenToRender (Grid.js:871)
    at Grid.componentWillUpdate (Grid.js:669)
    at ReactCompositeComponent.js:708
```

This is because the row rendering function does not correctly account for rows where data has not yet been loaded.
