### PR TITLE
Organize transcript track package

### DIFF
--- a/packages/track-transcript/package.json
+++ b/packages/track-transcript/package.json
@@ -7,14 +7,13 @@
     "lib"
   ],
   "dependencies": {
-    "@broad/utilities": "*",
-    "react-motion": "^0.5.0"
+    "@broad/utilities": "*"
   },
   "peerDependencies": {
     "@broad/track-region": "*",
     "prop-types": "^15.5.10",
-    "react": "^15.5.4",
     "ramda": "^0.24.1",
+    "react": "^15.5.4",
     "styled-components": "^2.1.2"
   }
 }

--- a/packages/track-transcript/src/GTEx.js
+++ b/packages/track-transcript/src/GTEx.js
@@ -1,0 +1,196 @@
+import { scaleLinear } from 'd3-scale'
+import PropTypes from 'prop-types'
+import R from 'ramda'
+import React from 'react'
+import styled from 'styled-components'
+
+import { QuestionMark } from '@broad/help'
+import { tissueMappings } from '@broad/utilities/src/constants/gtex'
+
+
+const GtexTitleWrapper = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 50px;
+  padding-left: 10px;
+  width: 100%;
+`
+
+
+const GtexTitleText = styled.a`
+  color: #428bca;
+  font-size: 13px;
+  margin-bottom: 5px;
+  text-decoration: none;
+`
+
+
+const GtexTissueSelect = styled.select`
+  font-size: 12px;
+  max-width: 100%;
+`
+
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: ${props => props.width}px;
+`
+
+
+export function TissueIsoformExpressionPlotHeader({
+  currentGene,
+  currentTissue,
+  onTissueChange,
+  tissueStats,
+  width,
+}) {
+  const allTissues = Array.from(tissueStats.keys()).sort()
+  const maxTissueValue = tissueStats.first()
+  const selectedTissue = currentTissue || 'median-across-all'
+  const padding = 10
+
+  const gtexScale = scaleLinear()
+    .domain([0, maxTissueValue + (maxTissueValue * 0.3)])
+    .range([padding, width - padding])
+
+  const plotAxis = (
+    <svg height={30} width={width}>
+      <line
+        x1={padding}
+        x2={width - padding}
+        y1={20}
+        y2={20}
+        stroke={'black'}
+        strokeWidth={1}
+      />
+      {gtexScale.ticks(5).map((x) => {
+        const xPos = gtexScale(x)
+        return (
+          <g key={`${x}-tick`}>
+            <line
+              x1={xPos}
+              x2={xPos}
+              y1={15}
+              y2={25}
+              stroke={'black'}
+              key={`${x}-xtick`}
+            />
+            <text
+              x={xPos}
+              y={13}
+              textAnchor={'middle'}
+              fontSize={8}
+            >
+              {x}
+            </text>
+          </g>
+        )
+      })}
+    </svg>
+  )
+
+  const options = allTissues.map(tissue => (
+    <option key={`${tissue}-option`} value={tissue}>
+      {tissueMappings[tissue]} {`(${tissueStats.get(tissue)})`}
+    </option>
+  ))
+
+  return (
+    <Wrapper width={width}>
+      <GtexTitleWrapper>
+        <GtexTitleText
+          href={`http://www.gtexportal.org/home/gene/${currentGene}`}
+          target="_blank"
+        >
+          {/* Tissue-specific isoform expression */}
+          Isoform expression
+          <QuestionMark topic={'gtex'} display={'inline'} />
+        </GtexTitleText>
+
+        <GtexTissueSelect
+          onChange={event => onTissueChange(event.target.value)}
+          value={selectedTissue}
+        >
+          <option key="median-across-all" value="median-across-all">
+            Median across all tissues ({R.median(Array.from(tissueStats.values()))})
+          </option>
+          <optgroup label="Specific tissue">
+            {options}
+          </optgroup>
+        </GtexTissueSelect>
+      </GtexTitleWrapper>
+      {plotAxis}
+    </Wrapper>
+  )
+}
+
+TissueIsoformExpressionPlotHeader.propTypes = {
+  currentGene: PropTypes.string.isRequired,
+  currentTissue: PropTypes.string,
+  onTissueChange: PropTypes.func.isRequired,
+  tissueStats: PropTypes.object.isRequired,
+  width: PropTypes.number.isRequired,
+}
+
+TissueIsoformExpressionPlotHeader.defaultProps = {
+  currentTissue: undefined,
+}
+
+
+export function TissueIsoformExpressionPlot({
+  height,
+  width,
+  transcript,
+  currentTissue,
+  tissueStats,
+}) {
+  const allTissues = Array.from(tissueStats.keys()).sort()
+  const maxTissueValue = tissueStats.first()
+  const selectedTissue = currentTissue || 'median-across-all'
+  const padding = 10
+
+  const gtexScale = scaleLinear()
+    .domain([0, maxTissueValue + (maxTissueValue * 0.3)])
+    .range([padding, width - padding])
+
+  const { gtex_tissue_tpms_by_transcript } = transcript
+  const tpm = selectedTissue === 'median-across-all'
+    ? R.median(allTissues.map(tissue => gtex_tissue_tpms_by_transcript[tissue]))
+    : gtex_tissue_tpms_by_transcript[selectedTissue]
+
+  return (
+    <Wrapper width={width}>
+      <svg height={height} width={width}>
+        <line
+          x1={padding}
+          x2={width - padding}
+          y1={height / 2}
+          y2={height / 2}
+          stroke={'black'}
+          strokeDasharray="1.5"
+        />
+        <circle
+          cx={gtexScale(tpm)}
+          cy={height / 2}
+          r={5}
+          fill={'black'}
+        />
+      </svg>
+    </Wrapper>
+  )
+}
+
+TissueIsoformExpressionPlot.propTypes = {
+  height: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired,
+  transcript: PropTypes.object.isRequired,
+  currentTissue: PropTypes.string,
+  tissueStats: PropTypes.object.isRequired,
+}
+
+TissueIsoformExpressionPlot.defaultProps = {
+  currentTissue: undefined,
+}

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -1,6 +1,4 @@
 /* eslint-disable react/prop-types */
-/* eslint-disable no-mixed-operators
- */
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
@@ -159,7 +157,6 @@ const Transcript = ({
   tissueStats,
   onTissueChange,
   showRightPanel,
-  showLeftPanel,
   currentGene,
   onTranscriptNameClick,
   currentTranscript,
@@ -185,7 +182,6 @@ const Transcript = ({
       />
     )
   }
-  showLeftPanel = true
 
   const rightPanel = isMaster
     ? (
@@ -216,16 +212,16 @@ const Transcript = ({
         opacity,
       }}
     >
-      {showLeftPanel &&
-        <TranscriptLeftPanel
-          leftPanelWidth={leftPanelWidth}
-          title={title}
-          fontSize={fontSize}
-          onTranscriptNameClick={onTranscriptNameClick}
-          currentTranscript={currentTranscript}
-          canonicalTranscript={canonicalTranscript}
-          expandTranscriptButton={expandTranscriptButton}
-        />}
+      <TranscriptLeftPanel
+        leftPanelWidth={leftPanelWidth}
+        title={title}
+        fontSize={fontSize}
+        onTranscriptNameClick={onTranscriptNameClick}
+        currentTranscript={currentTranscript}
+        canonicalTranscript={canonicalTranscript}
+        expandTranscriptButton={expandTranscriptButton}
+      />
+
       <div style={{ display: 'flex', justifyContent: 'center' }}>
         <TranscriptDrawing
           width={width}
@@ -258,8 +254,8 @@ const TranscriptGroupWrapper = styled.div`
 const TranscriptTrackContainer = styled.div`
   display: flex;
   flex-direction: column;
-  /*border: 1px solid orange;*/
 `
+
 
 export default class TranscriptTrack extends Component {
   static PropTypes = {
@@ -271,21 +267,9 @@ export default class TranscriptTrack extends Component {
     positionOffset: PropTypes.func,  // eslint-disable-line
   }
 
-  state = {
-    fanOutButtonOpen: true,
-  }
-
   config = {
     stiffness: 1000,
     damping: 50,
-  }
-
-  fanOut = () => {
-    if (!this.state.fanOutButtonOpen) {
-      this.setState({ fanOutButtonOpen: true })
-    } else {
-      this.setState({ fanOutButtonOpen: false })
-    }
   }
 
   initialTranscriptStyles = () => ({
@@ -296,8 +280,7 @@ export default class TranscriptTrack extends Component {
     opacity: 1,
   })
 
-  finalTranscriptStyles = (childIndex) => {
-    const deltaY = (childIndex + 1) * 2  // eslint-disable-line
+  finalTranscriptStyles = () => {
     return {
       top: spring(this.props.height, this.config),
       paddingTop: 2,
@@ -322,7 +305,7 @@ export default class TranscriptTrack extends Component {
   renderAlternateTranscripts() {
     const alternateTranscriptIds = Object.keys(this.props.transcriptsGrouped)
 
-    return alternateTranscriptIds.map((transcriptId, index) => {
+    return alternateTranscriptIds.map((transcriptId) => {
       const transcript = this.props.transcriptsGrouped[transcriptId]
       const transcriptExonsFiltered = transcript.exons.filter(exon => exon.feature_type === 'CDS')
 
@@ -331,7 +314,7 @@ export default class TranscriptTrack extends Component {
       }
 
       const style = this.props.transcriptFanOut
-        ? this.finalTranscriptStyles(index)
+        ? this.finalTranscriptStyles()
         : this.initialTranscriptStyles()
 
       return (

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -14,7 +14,36 @@ import {
   TissueIsoformExpressionPlot
 } from './GTEx'
 
+
 const flipOutExonThickness = 10
+
+
+const TranscriptLeftAxis = styled.div`
+  display: flex;
+  width: ${props => props.width}px;
+`
+
+const TranscriptName = styled.div`
+  color: black;
+  display: flex;
+  width: 100%;
+`
+
+const TranscriptLink = styled.a`
+  background-color: ${({ isSelected }) => isSelected ? 'rgba(10, 121, 191, 0.1);' : 'none;'}
+  border-bottom: ${({ isSelected, isCanonical }) => {
+    if (isSelected) {
+      return '1px solid red'
+    }
+    if (isCanonical) {
+      return '1px solid #000'
+    }
+    return 'none'
+  }};
+  cursor: pointer;
+  text-decoration: none;
+`
+
 
 const TranscriptLeftPanel = ({
   title,
@@ -25,33 +54,6 @@ const TranscriptLeftPanel = ({
   canonicalTranscript,
   onTranscriptNameClick,
 }) => {
-  const TranscriptLeftAxis = styled.div`
-    display: flex;
-    width: 100%; /* Set by Redux */
-  `
-  const TranscriptName = styled.div`
-  display: flex;
-  width: 100%; /* Set by Redux */
-  color: black;
-  `
-
-  const TranscriptLink = styled.a`
-    text-decoration: none;
-    cursor: pointer;
-    background-color: ${({ isSelected }) => isSelected ? 'rgba(10, 121, 191, 0.1);' : 'none;'}
-    border-bottom: ${({ isSelected, isCanonical }) => {{
-      if (isSelected) {
-        return'1px solid red'
-        return'1px solid #000'
-      }
-      if (isCanonical) {
-        return'1px solid #000'
-      }
-      return 'none'
-      }}};
-    ${'' /* border-radius: 3px; */}
-  `
-
   const contents = expandTranscriptButton ||
     <TranscriptLink
       isSelected={currentTranscript === title}
@@ -63,7 +65,7 @@ const TranscriptLeftPanel = ({
       {title}
     </TranscriptLink>
   return (
-    <TranscriptLeftAxis style={{ width: leftPanelWidth }}>
+    <TranscriptLeftAxis width={leftPanelWidth}>
       <TranscriptName style={{ fontSize }}>
         {contents}
       </TranscriptName>
@@ -126,6 +128,15 @@ const TranscriptDrawing = ({
   )
 }
 
+
+const TranscriptContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  padding-bottom: 3px;
+  padding-top: 3px;
+`
+
+
 const Transcript = ({
   width,
   height,
@@ -155,12 +166,6 @@ const Transcript = ({
   canonicalTranscript,
   strand,
 }) => {
-  const TranscriptContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    padding-bottom: 3px;
-    padding-top: 3px;
-  `
   let localHeight
   if (motionHeight !== undefined) {
     localHeight = motionHeight
@@ -243,6 +248,13 @@ Transcript.propTypes = {
   positionOffset: PropTypes.func,  // eslint-disable-line
 }
 
+
+const TranscriptGroupWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+
 const TranscriptGroup = ({
   transcriptsGrouped,
   fanOutButtonOpen,
@@ -250,10 +262,6 @@ const TranscriptGroup = ({
   finalTranscriptStyles,
   ...rest
 }) => {
-  const TranscriptGroupWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-  `
   const transcriptGroup = (
     <TranscriptGroupWrapper>
       {Object.keys(transcriptsGrouped).map((transcript, index) => {

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Motion, spring } from 'react-motion'
 import R from 'ramda'
 
 import TranscriptFlipOutButton from './transcriptFlipOutButton'
@@ -24,6 +23,7 @@ const TranscriptLeftAxis = styled.div`
 const TranscriptName = styled.div`
   color: black;
   display: flex;
+  font-size: 11px;
   width: 100%;
 `
 
@@ -46,7 +46,6 @@ const TranscriptLink = styled.a`
 const TranscriptLeftPanel = ({
   title,
   leftPanelWidth,
-  fontSize,
   expandTranscriptButton,
   currentTranscript,
   canonicalTranscript,
@@ -64,7 +63,7 @@ const TranscriptLeftPanel = ({
     </TranscriptLink>
   return (
     <TranscriptLeftAxis width={leftPanelWidth}>
-      <TranscriptName style={{ fontSize }}>
+      <TranscriptName>
         {contents}
       </TranscriptName>
     </TranscriptLeftAxis>
@@ -131,8 +130,8 @@ const TranscriptDrawing = ({
 const TranscriptContainer = styled.div`
   display: flex;
   flex-direction: row;
-  padding-bottom: 3px;
-  padding-top: 3px;
+  padding-bottom: 2px;
+  padding-top: 2px;
 `
 
 
@@ -146,11 +145,6 @@ const Transcript = ({
   positionOffset,
   isMaster,
   fanOut,
-  motionHeight,
-  paddingTop,
-  paddingBottom,
-  fontSize,
-  opacity,
   rightPanelWidth,
   fanOutButtonOpen,
   transcript,
@@ -164,17 +158,8 @@ const Transcript = ({
   canonicalTranscript,
   strand,
 }) => {
-  let localHeight
-  if (motionHeight !== undefined) {
-    localHeight = motionHeight
-  } else {
-    localHeight = height
-  }
   let expandTranscriptButton
   if (isMaster) {
-    localHeight = 80
-    paddingTop = 0  // eslint-disable-line
-    paddingBottom = 0  // eslint-disable-line
     expandTranscriptButton = (
       <TranscriptFlipOutButton
         fanOutIsOpen={fanOutButtonOpen}
@@ -205,34 +190,25 @@ const Transcript = ({
     )
 
   return (
-    <TranscriptContainer
-      style={{
-        height: localHeight,
-        paddingTop,
-        paddingBottom,
-        opacity,
-      }}
-    >
+    <TranscriptContainer>
       <TranscriptLeftPanel
         leftPanelWidth={leftPanelWidth}
         title={title}
-        fontSize={fontSize}
         onTranscriptNameClick={onTranscriptNameClick}
         currentTranscript={currentTranscript}
         canonicalTranscript={canonicalTranscript}
         expandTranscriptButton={expandTranscriptButton}
       />
 
-      <div style={{ display: 'flex', justifyContent: 'center' }}>
-        <TranscriptDrawing
-          width={width}
-          height={localHeight}
-          regions={regions}
-          xScale={xScale}
-          positionOffset={positionOffset}
-          isMaster={isMaster}
-        />
-      </div>
+      <TranscriptDrawing
+        width={width}
+        height={height}
+        regions={regions}
+        xScale={xScale}
+        positionOffset={positionOffset}
+        isMaster={isMaster}
+      />
+
       {showRightPanel && fanOutButtonOpen && rightPanel}
     </TranscriptContainer>
   )
@@ -268,35 +244,13 @@ export default class TranscriptTrack extends Component {
     positionOffset: PropTypes.func,  // eslint-disable-line
   }
 
-  config = {
-    stiffness: 1000,
-    damping: 50,
-  }
-
-  initialTranscriptStyles = () => ({
-    top: spring(0, this.config),
-    paddingTop: 0,
-    paddingBottom: 0,
-    fontSize: 0,
-    opacity: 1,
-  })
-
-  finalTranscriptStyles = () => {
-    return {
-      top: spring(this.props.height, this.config),
-      paddingTop: 2,
-      paddingBottom: 2,
-      fontSize: 11,
-      opacity: 1,
-    }
-  }
-
   renderCanonicalTranscript() {
     return (
       <Transcript
         {...this.props}
         fanOut={this.props.transcriptButtonOnClick}
         fanOutButtonOpen={this.props.transcriptFanOut}
+        height={80}
         isMaster
         regions={this.props.offsetRegions}
       />
@@ -314,35 +268,15 @@ export default class TranscriptTrack extends Component {
         return null
       }
 
-      const style = this.props.transcriptFanOut
-        ? this.finalTranscriptStyles()
-        : this.initialTranscriptStyles()
-
       return (
-        <Motion style={style} key={transcriptId}>
-          {({
-            top,
-            paddingTop,
-            paddingBottom,
-            fontSize,
-            opacity,
-          }) => {
-            return (
-              <Transcript
-                {...this.props}
-                title={transcriptId}
-                motionHeight={top}
-                paddingTop={paddingTop}
-                paddingBottom={paddingBottom}
-                fontSize={fontSize}
-                opacity={opacity}
-                regions={transcriptExonsFiltered}
-                fanOutButtonOpen={this.props.transcriptFanOut}
-                transcript={transcript}
-              />
-            )
-          }}
-        </Motion>
+        <Transcript
+          {...this.props}
+          key={transcriptId}
+          title={transcriptId}
+          regions={transcriptExonsFiltered}
+          fanOutButtonOpen={this.props.transcriptFanOut}
+          transcript={transcript}
+        />
       )
     })
   }
@@ -353,7 +287,7 @@ export default class TranscriptTrack extends Component {
         {this.renderCanonicalTranscript()}
         {this.props.transcriptsGrouped && (
           <TranscriptGroupWrapper>
-            {this.renderAlternateTranscripts()}
+            {this.props.transcriptFanOut && this.renderAlternateTranscripts()}
           </TranscriptGroupWrapper>
         )}
       </TranscriptTrackContainer>

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -5,13 +5,14 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Motion, spring } from 'react-motion'
-import { scaleLinear } from 'd3-scale'
 import R from 'ramda'
 
-import { tissueMappings } from '@broad/utilities/src/constants/gtex'
-import { QuestionMark } from '@broad/help'
-
 import TranscriptFlipOutButton from './transcriptFlipOutButton'
+
+import {
+  TissueIsoformExpressionPlotHeader,
+  TissueIsoformExpressionPlot
+} from './GTEx'
 
 const flipOutExonThickness = 10
 
@@ -40,14 +41,14 @@ const TranscriptLeftPanel = ({
     background-color: ${({ isSelected }) => isSelected ? 'rgba(10, 121, 191, 0.1);' : 'none;'}
     border-bottom: ${({ isSelected, isCanonical }) => {{
       if (isSelected) {
-        return'1px solid red;'
-        return'1px solid #000;'
+        return'1px solid red'
+        return'1px solid #000'
       }
       if (isCanonical) {
-        return'1px solid #000;'
+        return'1px solid #000'
       }
       return 'none'
-      }}}
+      }}};
     ${'' /* border-radius: 3px; */}
   `
 
@@ -75,177 +76,6 @@ TranscriptLeftPanel.propTypes = {
 }
 TranscriptLeftPanel.defaultProps = {
   title: '',
-}
-
-const TranscriptRightPanelWrapper = styled.div`
-  display: flex;
-  width: 100%; /* Set by Redux */
-  height: 100%;
-  ${'' /* border: 1px solid blue; */}
-
-`
-const TranscriptName = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%; /* Set by Redux */
-  color: black;
-  ${'' /* border: 3px solid blue; */}
-`
-
-const GtexTitleWrapper = styled.div`
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 70%;
-  padding-left: 10px;
-`
-
-const GtexPlotWrapper = styled.div``
-
-const GtexTitleText = styled.a`
-  font-size: 13px;
-  margin-bottom: 5px;
-  text-decoration: none;
-  color: #428bca;
-`
-const GtexTissueSelect = styled.select`
-  max-width: 100%;
-  font-size: 12px;
-`
-
-const TranscriptRightPanel = ({
-  rightPanelWidth,
-  transcript,
-  fanOutButtonOpen,
-  currentTissue,
-  tissueStats,
-  onTissueChange,
-  isMaster,
-  masterHeight,
-  currentGene,
-}) => {
-  const allTissues = Array.from(tissueStats.keys()).sort()
-  const maxTissueValue = tissueStats.first()
-  const selectedTissue = currentTissue || 'median-across-all'
-  const padding = 10
-
-  const gtexScale = scaleLinear()
-    .domain([0, maxTissueValue + (maxTissueValue * 0.3)])
-    .range([padding, rightPanelWidth - padding])
-
-  const GtexPlot = () => {
-    const { gtex_tissue_tpms_by_transcript } = transcript
-    const tpm = selectedTissue === 'median-across-all'
-      ? R.median(allTissues.map(tissue => gtex_tissue_tpms_by_transcript[tissue]))
-      : gtex_tissue_tpms_by_transcript[selectedTissue]
-
-    return (
-      <svg height={flipOutExonThickness} width={rightPanelWidth}>
-        <line
-          x1={padding}
-          x2={rightPanelWidth - padding}
-          y1={flipOutExonThickness / 2}
-          y2={flipOutExonThickness / 2}
-          stroke={'black'}
-          strokeDasharray="1.5"
-        />
-        <circle
-          cx={gtexScale(tpm)}
-          cy={flipOutExonThickness / 2}
-          r={5}
-          fill={'black'}
-          onClick={() => onTissueChange('hello')}
-        />
-      </svg>
-    )
-  }
-
-  const GtexPlotAxis = () => {
-    const axisHeight = masterHeight / 3
-    return (
-      <svg height={axisHeight} width={rightPanelWidth}>
-        <line
-          x1={padding}
-          x2={rightPanelWidth - padding}
-          y1={axisHeight - axisHeight / 3}
-          y2={axisHeight - axisHeight / 3}
-          stroke={'black'}
-          strokeWidth={1}
-        />
-        {gtexScale.ticks(5).map((x) => {
-          const xPos = gtexScale(x)
-          return (
-            <g key={`${x}-tick`}>
-              <line
-                x1={xPos}
-                x2={xPos}
-                y1={axisHeight - 5 - axisHeight / 3}
-                y2={axisHeight + 5 - axisHeight / 3}
-                stroke={'black'}
-                key={`${x}-xtick`}
-              />
-              <text
-                x={xPos}
-                y={axisHeight - 6 - axisHeight / 3}
-                textAnchor={'middle'}
-                fontSize={8}
-              >
-                {x}
-              </text>
-            </g>
-          )
-        })}
-      </svg>
-    )
-  }
-  if (isMaster) {
-    const options = allTissues.map(tissue => (
-      <option key={`${tissue}-option`} value={tissue}>
-        {tissueMappings[tissue]} {`(${tissueStats.get(tissue)})`}
-      </option>
-    ))
-    return (
-      <TranscriptRightPanelWrapper style={{ width: rightPanelWidth }}>
-        <TranscriptName>
-          <GtexTitleWrapper>
-            {/* <GtexTitleText>GTEx (mTPM)</GtexTitleText> */}
-            {/* <GtexTitleText>GTEx tissue-specific isoform expression (median TPM)</GtexTitleText> */}
-            <GtexTitleText
-              href={`http://www.gtexportal.org/home/gene/${currentGene}`}
-              target="_blank"
-              >
-              {/* Tissue-specific isoform expression */}
-              Isoform expression
-              <QuestionMark topic={'gtex'} display={'inline'} />
-            </GtexTitleText>
-            <GtexTissueSelect
-              onChange={event => onTissueChange(event.target.value)}
-              value={selectedTissue}
-            >
-              <option key="median-across-all" value="median-across-all">
-                Median across all tissues ({R.median(Array.from(tissueStats.values()))})
-              </option>
-              <optgroup label="Specific tissue">
-                {options}
-              </optgroup>
-            </GtexTissueSelect>
-          </GtexTitleWrapper>
-          <GtexPlotWrapper>
-            <GtexPlotAxis />
-          </GtexPlotWrapper>
-        </TranscriptName>
-      </TranscriptRightPanelWrapper>
-    )
-  }
-
-  return (
-    <TranscriptRightPanelWrapper style={{ width: rightPanelWidth }}>
-      <TranscriptName>
-        <GtexPlot />
-      </TranscriptName>
-    </TranscriptRightPanelWrapper>
-  )
 }
 
 const TranscriptDrawing = ({
@@ -315,7 +145,6 @@ const Transcript = ({
   fanOutButtonOpen,
   transcript,
   currentTissue,
-  maxTissue,
   tissueStats,
   onTissueChange,
   showRightPanel,
@@ -352,6 +181,27 @@ const Transcript = ({
     )
   }
   showLeftPanel = true
+
+  const rightPanel = isMaster
+    ? (
+      <TissueIsoformExpressionPlotHeader
+        currentGene={currentGene}
+        currentTissue={currentTissue}
+        onTissueChange={onTissueChange}
+        tissueStats={tissueStats}
+        width={rightPanelWidth}
+      />
+    )
+    : (
+      <TissueIsoformExpressionPlot
+        currentTissue={currentTissue}
+        height={flipOutExonThickness}
+        tissueStats={tissueStats}
+        transcript={transcript}
+        width={rightPanelWidth}
+      />
+    )
+
   return (
     <TranscriptContainer
       style={{
@@ -381,21 +231,7 @@ const Transcript = ({
           isMaster={isMaster}
         />
       </div>
-      {showRightPanel && fanOutButtonOpen &&
-        <TranscriptRightPanel
-          rightPanelWidth={rightPanelWidth}
-          title={title}
-          fontSize={fontSize}
-          transcript={transcript}
-          currentTissue={currentTissue}
-          maxTissue={maxTissue}
-          tissueStats={tissueStats}
-          onTissueChange={onTissueChange}
-          fanOutButtonOpen={fanOutButtonOpen}
-          isMaster={isMaster}
-          masterHeight={localHeight}
-          currentGene={currentGene}
-        />}
+      {showRightPanel && fanOutButtonOpen && rightPanel}
     </TranscriptContainer>
   )
 }

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -99,7 +99,7 @@ const TranscriptDrawing = ({
         stroke={'#BDBDBD'}
         strokeWidth={2}
       />
-      {regions.map((region, i) => {  // eslint-disable-line
+      {regions.map((region) => {
         const start = positionOffset(region.start)
         const stop = positionOffset(region.stop)
         let localThickness
@@ -117,10 +117,11 @@ const TranscriptDrawing = ({
               y2={height / 2}
               stroke={start.color}
               strokeWidth={localThickness}
-              key={`${i}-rectangle2`}
+              key={`${region.start}`}
             />
           )
         }
+        return null
       })}
     </svg>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -8326,12 +8326,6 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
-raf@^3.1.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
-  dependencies:
-    performance-now "^2.1.0"
-
 ramda@^0.22.1:
   version "0.22.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.22.1.tgz#031da0c3df417c5b33c96234757eb37033f36a0e"
@@ -8497,14 +8491,6 @@ react-input-autosize@^2.1.2:
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
   dependencies:
     prop-types "^15.5.8"
-
-react-motion@^0.5.0:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
-  dependencies:
-    performance-now "^0.2.0"
-    prop-types "^15.5.8"
-    raf "^3.1.0"
 
 react-popper@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
While working on the request to navigate between transcripts with the back button, I ran into a need to parameterize how the transcript ID links are rendered. And went down a bit of a rabbit hole organizing the code in TranscriptTrack.js to make that easier.

* Split GTEx components for right panel into separate file
* Move component definitions out of render functions
* Remove some unused code
* Remove the animation for showing/hiding the list of alternate transcripts
  This animation currently doesn't work anyway. Moving the definitions of styled components out of render functions fixed it, but it's extremely slow and jumpy for genes with many transcripts (ex BRCA1). If we're going to animate toggling the list, we should maybe fade out the entire group in CSS vs animating several properties of each transcript in JS. 