### PR TITLE
Add prop to to control how transcript ID is rendered in TranscriptTrack

### DIFF
--- a/packages/track-transcript/src/TranscriptConnected.js
+++ b/packages/track-transcript/src/TranscriptConnected.js
@@ -29,7 +29,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   onTissueChange: bindActionCreators(geneActions.setCurrentTissue, dispatch),
-  onTranscriptNameClick: bindActionCreators(geneActions.setCurrentTranscript, dispatch),
+  setCurrentTranscript: bindActionCreators(geneActions.setCurrentTranscript, dispatch),
   transcriptButtonOnClick: bindActionCreators(geneActions.toggleTranscriptFanOut, dispatch),
 })
 

--- a/packages/track-transcript/src/TranscriptConnected.js
+++ b/packages/track-transcript/src/TranscriptConnected.js
@@ -6,8 +6,6 @@ import {
   currentTissue,
   currentTranscript,
   canonicalTranscript,
-  currentExon,
-  transcripts,
   transcriptsGrouped,
   transcriptFanOut,
   tissueStats,
@@ -23,8 +21,6 @@ const mapStateToProps = state => ({
   currentTissue: currentTissue(state),
   currentTranscript: currentTranscript(state),
   canonicalTranscript: canonicalTranscript(state),
-  currentExon: currentExon(state),
-  transcripts: transcripts(state),
   transcriptsGrouped: transcriptsGrouped(state),
   tissueStats: tissueStats(state),
   transcriptFanOut: transcriptFanOut(state),
@@ -32,7 +28,6 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  onExonClick: bindActionCreators(geneActions.setCurrentExon, dispatch),
   onTissueChange: bindActionCreators(geneActions.setCurrentTissue, dispatch),
   onTranscriptNameClick: bindActionCreators(geneActions.setCurrentTranscript, dispatch),
   transcriptButtonOnClick: bindActionCreators(geneActions.toggleTranscriptFanOut, dispatch),

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -28,7 +28,7 @@ const TranscriptName = styled.div`
 `
 
 const TranscriptLink = styled.a`
-  background-color: ${({ isSelected }) => isSelected ? 'rgba(10, 121, 191, 0.1);' : 'none;'}
+  background-color: ${({ isSelected }) => isSelected ? 'rgba(10, 121, 191, 0.1)' : 'none'};
   border-bottom: ${({ isSelected, isCanonical }) => {
     if (isSelected) {
       return '1px solid red'
@@ -44,37 +44,25 @@ const TranscriptLink = styled.a`
 
 
 const TranscriptLeftPanel = ({
-  title,
-  leftPanelWidth,
-  expandTranscriptButton,
-  currentTranscript,
-  canonicalTranscript,
-  onTranscriptNameClick,
+  children,
+  width,
 }) => {
-  const contents = expandTranscriptButton ||
-    <TranscriptLink
-      isSelected={currentTranscript === title}
-      isCanonical={canonicalTranscript === title}
-      onClick={() => {
-        onTranscriptNameClick(title)
-      }}
-    >
-      {title}
-    </TranscriptLink>
   return (
-    <TranscriptLeftAxis width={leftPanelWidth}>
+    <TranscriptLeftAxis width={width}>
       <TranscriptName>
-        {contents}
+        {children}
       </TranscriptName>
     </TranscriptLeftAxis>
   )
 }
+
 TranscriptLeftPanel.propTypes = {
-  title: PropTypes.string,
-  leftPanelWidth: PropTypes.number.isRequired,
+  children: PropTypes.node,
+  width: PropTypes.number.isRequired,
 }
+
 TranscriptLeftPanel.defaultProps = {
-  title: '',
+  children: undefined,
 }
 
 const TranscriptDrawing = ({
@@ -158,16 +146,24 @@ const Transcript = ({
   canonicalTranscript,
   strand,
 }) => {
-  let expandTranscriptButton
-  if (isMaster) {
-    expandTranscriptButton = (
+  const leftPanelContent = isMaster
+    ? (
       <TranscriptFlipOutButton
         fanOutIsOpen={fanOutButtonOpen}
         strand={strand}
         onClick={fanOut}
       />
+    ) : (
+      <TranscriptLink
+        isCanonical={canonicalTranscript === title}
+        isSelected={currentTranscript === title}
+        onClick={() => {
+          onTranscriptNameClick(title)
+        }}
+      >
+        {title}
+      </TranscriptLink>
     )
-  }
 
   const rightPanel = isMaster
     ? (
@@ -191,14 +187,9 @@ const Transcript = ({
 
   return (
     <TranscriptContainer>
-      <TranscriptLeftPanel
-        leftPanelWidth={leftPanelWidth}
-        title={title}
-        onTranscriptNameClick={onTranscriptNameClick}
-        currentTranscript={currentTranscript}
-        canonicalTranscript={canonicalTranscript}
-        expandTranscriptButton={expandTranscriptButton}
-      />
+      <TranscriptLeftPanel width={leftPanelWidth}>
+        {leftPanelContent}
+      </TranscriptLeftPanel>
 
       <TranscriptDrawing
         width={width}

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -15,17 +15,13 @@ import {
 const flipOutExonThickness = 10
 
 
-const TranscriptLeftAxis = styled.div`
-  display: flex;
-  width: ${props => props.width}px;
-`
-
-const TranscriptName = styled.div`
+const TranscriptLeftPanel = styled.div`
   color: black;
   display: flex;
   font-size: 11px;
-  width: 100%;
+  width: ${props => props.width}px;
 `
+
 
 const TranscriptLink = styled.a`
   background-color: ${({ isSelected }) => isSelected ? 'rgba(10, 121, 191, 0.1)' : 'none'};
@@ -42,19 +38,6 @@ const TranscriptLink = styled.a`
   text-decoration: none;
 `
 
-
-const TranscriptLeftPanel = ({
-  children,
-  width,
-}) => {
-  return (
-    <TranscriptLeftAxis width={width}>
-      <TranscriptName>
-        {children}
-      </TranscriptName>
-    </TranscriptLeftAxis>
-  )
-}
 
 TranscriptLeftPanel.propTypes = {
   children: PropTypes.node,

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -193,12 +193,6 @@ Transcript.defaultProps = {
 }
 
 
-const TranscriptGroupWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-`
-
-
 const TranscriptTrackContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -268,6 +262,10 @@ export default class TranscriptTrack extends Component {
   }
 
   renderAlternateTranscripts() {
+    if (!this.props.transcriptsGrouped || !this.props.transcriptFanOut) {
+      return null
+    }
+
     const alternateTranscriptIds = Object.keys(this.props.transcriptsGrouped)
 
     return alternateTranscriptIds.map((transcriptId) => {
@@ -304,11 +302,7 @@ export default class TranscriptTrack extends Component {
     return (
       <TranscriptTrackContainer>
         {this.renderCanonicalTranscript()}
-        {this.props.transcriptsGrouped && (
-          <TranscriptGroupWrapper>
-            {this.props.transcriptFanOut && this.renderAlternateTranscripts()}
-          </TranscriptGroupWrapper>
-        )}
+        {this.renderAlternateTranscripts()}
       </TranscriptTrackContainer>
     )
   }

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
@@ -91,6 +90,22 @@ const TranscriptDrawing = ({
   )
 }
 
+TranscriptDrawing.propTypes = {
+  height: PropTypes.number.isRequired,
+  positionOffset: PropTypes.func.isRequired,
+  regions: PropTypes.arrayOf(PropTypes.shape({
+    start: PropTypes.number.isRequired,
+    stop: PropTypes.number.isRequired,
+  })).isRequired,
+  regionStrokeWidth: PropTypes.number,
+  width: PropTypes.number.isRequired,
+  xScale: PropTypes.func.isRequired,
+}
+
+TranscriptDrawing.defaultProps = {
+  regionStrokeWidth: undefined,
+}
+
 
 const TranscriptContainer = styled.div`
   display: flex;
@@ -151,12 +166,30 @@ const Transcript = ({
     </TranscriptContainer>
   )
 }
+
 Transcript.propTypes = {
+  canonicalTranscript: PropTypes.string.isRequired,
+  currentTissue: PropTypes.string,
+  currentTranscript: PropTypes.string,
   height: PropTypes.number.isRequired,
-  width: PropTypes.number, // eslint-disable-line
-  leftPanelWidth: PropTypes.number, // eslint-disable-line
-  xScale: PropTypes.func, // eslint-disable-line
-  positionOffset: PropTypes.func,  // eslint-disable-line
+  leftPanelWidth: PropTypes.number.isRequired,
+  onTranscriptNameClick: PropTypes.func.isRequired,
+  positionOffset: PropTypes.func.isRequired,
+  regions: PropTypes.arrayOf(PropTypes.shape({
+    start: PropTypes.number.isRequired,
+    stop: PropTypes.number.isRequired,
+  })).isRequired,
+  rightPanelWidth: PropTypes.number.isRequired,
+  showRightPanel: PropTypes.bool.isRequired,
+  tissueStats: PropTypes.object.isRequired,
+  transcript: PropTypes.object.isRequired,
+  width: PropTypes.number.isRequired,
+  xScale: PropTypes.func.isRequired,
+}
+
+Transcript.defaultProps = {
+  currentTissue: null,
+  currentTranscript: null,
 }
 
 
@@ -173,13 +206,33 @@ const TranscriptTrackContainer = styled.div`
 
 
 export default class TranscriptTrack extends Component {
-  static PropTypes = {
+  static propTypes = {
+    canonicalTranscript: PropTypes.string.isRequired,
+    currentGene: PropTypes.string,
+    currentTissue: PropTypes.string,
+    currentTranscript: PropTypes.string,
     height: PropTypes.number.isRequired,
-    width: PropTypes.number, // eslint-disable-line
-    leftPanelWidth: PropTypes.number, // eslint-disable-line
-    rightPanelWidth: PropTypes.number, // eslint-disable-line
-    xScale: PropTypes.func, // eslint-disable-line
-    positionOffset: PropTypes.func,  // eslint-disable-line
+    leftPanelWidth: PropTypes.number.isRequired,
+    offsetRegions: PropTypes.arrayOf(PropTypes.object).isRequired,
+    onTissueChange: PropTypes.func.isRequired,
+    onTranscriptNameClick: PropTypes.func.isRequired,
+    positionOffset: PropTypes.func.isRequired,
+    rightPanelWidth: PropTypes.number.isRequired,
+    showRightPanel: PropTypes.bool,
+    strand: PropTypes.string.isRequired,
+    tissueStats: PropTypes.object.isRequired,
+    transcriptButtonOnClick: PropTypes.func.isRequired,
+    transcriptFanOut: PropTypes.bool.isRequired,
+    transcriptsGrouped: PropTypes.object.isRequired,
+    width: PropTypes.number.isRequired,
+    xScale: PropTypes.func.isRequired,
+  }
+
+  static defaultProps = {
+    currentGene: null,
+    currentTissue: null,
+    currentTranscript: null,
+    showRightPanel: true,
   }
 
   renderCanonicalTranscript() {
@@ -227,11 +280,21 @@ export default class TranscriptTrack extends Component {
 
       return (
         <Transcript
-          {...this.props}
           key={transcriptId}
+          canonicalTranscript={this.props.canonicalTranscript}
+          currentTissue={this.props.currentTissue}
+          currentTranscript={this.props.currentTranscript}
+          height={this.props.height}
+          leftPanelWidth={this.props.leftPanelWidth}
+          onTranscriptNameClick={this.props.onTranscriptNameClick}
+          positionOffset={this.props.positionOffset}
           regions={transcriptExonsFiltered}
+          rightPanelWidth={this.props.rightPanelWidth}
           showRightPanel={this.props.showRightPanel && this.props.transcriptFanOut}
+          tissueStats={this.props.tissueStats}
           transcript={transcript}
+          xScale={this.props.xScale}
+          width={this.props.width}
         />
       )
     })

--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -22,19 +22,22 @@ const TranscriptLeftPanel = styled.div`
 `
 
 
-const TranscriptLink = styled.a`
-  background-color: ${({ isSelected }) => isSelected ? 'rgba(10, 121, 191, 0.1)' : 'none'};
-  border-bottom: ${({ isSelected, isCanonical }) => {
+const TranscriptIdButton = styled.button`
+  -webkit-appearance: none;
+  background: ${({ isSelected }) => isSelected ? 'rgba(10, 121, 191, 0.1)' : 'none'};
+  border-color: ${({ isSelected, isCanonical }) => {
     if (isSelected) {
-      return '1px solid red'
+      return 'red'
     }
     if (isCanonical) {
-      return '1px solid #000'
+      return 'black'
     }
-    return 'none'
+    return '#fff0'
   }};
+  border-style: solid;
+  border-width: 0 0 1px 0;
   cursor: pointer;
-  text-decoration: none;
+  padding: 0;
 `
 
 
@@ -127,22 +130,17 @@ const Transcript = ({
   currentTissue,
   tissueStats,
   showRightPanel,
-  onTranscriptNameClick,
   currentTranscript,
   canonicalTranscript,
+  renderTranscriptId,
 }) => {
   return (
     <TranscriptContainer>
       <TranscriptLeftPanel width={leftPanelWidth}>
-        <TranscriptLink
-          isCanonical={canonicalTranscript === transcript.transcript_id}
-          isSelected={currentTranscript === transcript.transcript_id}
-          onClick={() => {
-            onTranscriptNameClick(transcript.transcript_id)
-          }}
-        >
-          {transcript.transcript_id}
-        </TranscriptLink>
+        {renderTranscriptId(transcript.transcript_id, {
+          isCanonical: canonicalTranscript === transcript.transcript_id,
+          isSelected: currentTranscript === transcript.transcript_id,
+        })}
       </TranscriptLeftPanel>
 
       <TranscriptDrawing
@@ -173,12 +171,12 @@ Transcript.propTypes = {
   currentTranscript: PropTypes.string,
   height: PropTypes.number.isRequired,
   leftPanelWidth: PropTypes.number.isRequired,
-  onTranscriptNameClick: PropTypes.func.isRequired,
   positionOffset: PropTypes.func.isRequired,
   regions: PropTypes.arrayOf(PropTypes.shape({
     start: PropTypes.number.isRequired,
     stop: PropTypes.number.isRequired,
   })).isRequired,
+  renderTranscriptId: PropTypes.func.isRequired,
   rightPanelWidth: PropTypes.number.isRequired,
   showRightPanel: PropTypes.bool.isRequired,
   tissueStats: PropTypes.object.isRequired,
@@ -209,9 +207,10 @@ export default class TranscriptTrack extends Component {
     leftPanelWidth: PropTypes.number.isRequired,
     offsetRegions: PropTypes.arrayOf(PropTypes.object).isRequired,
     onTissueChange: PropTypes.func.isRequired,
-    onTranscriptNameClick: PropTypes.func.isRequired,
     positionOffset: PropTypes.func.isRequired,
+    renderTranscriptId: PropTypes.func,
     rightPanelWidth: PropTypes.number.isRequired,
+    setCurrentTranscript: PropTypes.func.isRequired,
     showRightPanel: PropTypes.bool,
     strand: PropTypes.string.isRequired,
     tissueStats: PropTypes.object.isRequired,
@@ -226,6 +225,7 @@ export default class TranscriptTrack extends Component {
     currentGene: null,
     currentTissue: null,
     currentTranscript: null,
+    renderTranscriptId: undefined,
     showRightPanel: true,
   }
 
@@ -261,6 +261,18 @@ export default class TranscriptTrack extends Component {
     )
   }
 
+  renderTranscriptId = (transcriptId, { isCanonical, isSelected }) => {
+    return (
+      <TranscriptIdButton
+        isCanonical={isCanonical}
+        isSelected={isSelected}
+        onClick={() => this.props.setCurrentTranscript(transcriptId)}
+      >
+        {transcriptId}
+      </TranscriptIdButton>
+    )
+  }
+
   renderAlternateTranscripts() {
     if (!this.props.transcriptsGrouped || !this.props.transcriptFanOut) {
       return null
@@ -287,6 +299,7 @@ export default class TranscriptTrack extends Component {
           onTranscriptNameClick={this.props.onTranscriptNameClick}
           positionOffset={this.props.positionOffset}
           regions={transcriptExonsFiltered}
+          renderTranscriptId={this.props.renderTranscriptId || this.renderTranscriptId}
           rightPanelWidth={this.props.rightPanelWidth}
           showRightPanel={this.props.showRightPanel && this.props.transcriptFanOut}
           tissueStats={this.props.tissueStats}


### PR DESCRIPTION
The end goal here is to make gnomAD's transcript IDs into links for #97. However, not every browser will make use of a selected transcript, so this allows the TranscriptTrack to be tailored to the browser's needs.

Also:
* Combine/remove some styled components.
* Use Transcript component only for transcripts in the expanded list. This removes several checks for `isMaster` in Transcript and its subcomponents.
* Add prop types for more thorough API documentation.