### PR TITLE
Load canonical transcript and strand for SCHEMA gene page

### DIFF
--- a/packages/track-transcript/src/TranscriptTrack.js
+++ b/packages/track-transcript/src/TranscriptTrack.js
@@ -296,7 +296,6 @@ export default class TranscriptTrack extends Component {
           currentTranscript={this.props.currentTranscript}
           height={this.props.height}
           leftPanelWidth={this.props.leftPanelWidth}
-          onTranscriptNameClick={this.props.onTranscriptNameClick}
           positionOffset={this.props.positionOffset}
           regions={transcriptExonsFiltered}
           renderTranscriptId={this.props.renderTranscriptId || this.renderTranscriptId}

--- a/projects/schizophrenia/src/ExomePage/fetch.js
+++ b/projects/schizophrenia/src/ExomePage/fetch.js
@@ -2,7 +2,7 @@ import fetch from 'graphql-fetch'
 
 const API_URL = process.env.GNOMAD_API_URL
 
-export const fetchSchz = (geneName, options, url = API_URL) => {
+export const fetchSchz = (geneName) => {
   const query = `{
     gene(gene_name: "${geneName}") {
       gene_id
@@ -13,6 +13,8 @@ export const fetchSchz = (geneName, options, url = API_URL) => {
       stop
       xstart
       xstop
+      canonical_transcript
+      strand
       schzGeneResult {
         gene_name
         description
@@ -181,11 +183,6 @@ export const fetchSchz = (geneName, options, url = API_URL) => {
   }
 }`
 
-  return new Promise((resolve, reject) => {
-    fetch(url)(query)
-      .then(data => resolve(data.data.gene))
-      .catch((error) => {
-        reject(error)
-      })
-  })
+  return fetch(API_URL)(query)
+    .then(data => data.data.gene)
 }


### PR DESCRIPTION
Currently, the transcript track on the SCHEMA browser's gene page is missing some information because the canonical transcript and strand is not retrieved from the API.