### PR TITLE
Remove incorrect gene caching code

### DIFF
--- a/packages/redux-genes/src/GenePageHoc.js
+++ b/packages/redux-genes/src/GenePageHoc.js
@@ -112,14 +112,9 @@ const GenePageContainer = ComposedComponent => class GenePage extends Component 
 
 const mapDispatchToProps = geneFetchFunction => dispatch => ({
   fetchGeneData(geneName, transcriptId) {
-    return dispatch((thunkDispatch, getState) => {
+    return dispatch((thunkDispatch) => {
       thunkDispatch(geneActions.setCurrentGene(geneName))
       thunkDispatch(geneActions.setCurrentTranscript(transcriptId))
-
-      const state = getState()
-      if (state.genes.allGeneNames[geneName]) {
-        return Promise.resolve(state.genes.byGeneName.get(geneName))
-      }
 
       thunkDispatch(geneActions.requestGeneData(geneName))
       return geneFetchFunction(geneName, transcriptId)


### PR DESCRIPTION
Fix up for #106.

a) This code is incorrect. `allGeneNames[geneName]` is always undefined because you can't test membership in Immutable.Set with a bracket operator.
b) If this code did work, it would break the gene page since it would not load variants for the specified transcript.