### PR TITLE
Fetch ClinVar data from latest index

### DIFF
--- a/packages/api/src/schema/types/clinvar.js
+++ b/packages/api/src/schema/types/clinvar.js
@@ -65,7 +65,6 @@ export function lookupClinvarVariantsByGeneId(client, geneId) {
           bool: {
             filter: [
               { term: { gene_ids: geneId } },
-              { exists: { field: 'main_transcript_hgvsp' } },
             ],
           },
         },

--- a/packages/api/src/schema/types/gene.js
+++ b/packages/api/src/schema/types/gene.js
@@ -32,7 +32,7 @@ import {
 import minimalVariantType, { lookupMinimalVariants } from './minimalVariant'
 import elasticVariantType, { lookupElasticVariantsByGeneId } from './elasticVariant'
 import * as fromExacVariant from './exacElasticVariant'
-import clinvarType, { lookupClinvarVariantsByGeneName } from './clinvar'
+import clinvarType, { lookupClinvarVariantsByGeneId } from './clinvar'
 
 import * as fromRegionalConstraint from './regionalConstraint'
 
@@ -172,7 +172,7 @@ const geneType = new GraphQLObjectType({
     clinvar_variants: {
       type: new GraphQLList(clinvarType),
       resolve: (obj, args, ctx) =>
-        lookupClinvarVariantsByGeneName(ctx.database.elastic, obj.gene_name),
+        lookupClinvarVariantsByGeneId(ctx.database.elastic, obj.gene_id),
     },
     transcript: {
       type: transcriptType,


### PR DESCRIPTION
Get ClinVar variants from an index populated by https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/master/hail_scripts/load_clinvar_to_es_pipeline.py.

Address @bw2's comment about querying by gene ID instead of symbol.