### PR TITLE
Update ClinVar variant query

### DIFF
--- a/packages/api/src/schema/types/clinvar.js
+++ b/packages/api/src/schema/types/clinvar.js
@@ -64,7 +64,7 @@ export function lookupClinvarVariantsByGeneId(client, geneId) {
         query: {
           bool: {
             filter: [
-              { term: { gene_ids: geneId } },
+              { term: { main_transcript_gene_id: geneId } },
             ],
           },
         },


### PR DESCRIPTION
The track in #90 displays ClinVar variants' main transcript's major consequence. Thus, a variant should be included in the track based on the gene ID of the variant's main transcript, not the list of all gene IDs in which the variant appears. Otherwise, the track may show an incorrect consequence for the current gene.