### PR TITLE
Allow interaction with tooltip content

### DIFF
--- a/packages/ui/src/example/TooltipExample.js
+++ b/packages/ui/src/example/TooltipExample.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+import { withTooltip } from '..'
+
+
+const WithTooltip = withTooltip(props => <span>{props.tooltip}</span>)
+
+
+const TextWithTooltip = ({ text }) => (
+  <WithTooltip tooltip={text}>
+    <span>{text}</span>
+  </WithTooltip>
+)
+
+
+export default () => <TextWithTooltip text="Hello world" />

--- a/packages/ui/src/example/index.js
+++ b/packages/ui/src/example/index.js
@@ -8,6 +8,7 @@ import {
 } from '../index'
 
 import SegmentedControlExample from './SegmentedControlExample'
+import TooltipExample from './TooltipExample'
 
 
 const ExampleContainer = styled.section`
@@ -38,6 +39,9 @@ const UiExample = () => {
       </ExampleItem>
       <ExampleItem>
         <SegmentedControlExample />
+      </ExampleItem>
+      <ExampleItem>
+        <TooltipExample />
       </ExampleItem>
     </ExampleContainer>
   )

--- a/packages/ui/src/tooltip/withTooltip.js
+++ b/packages/ui/src/tooltip/withTooltip.js
@@ -20,6 +20,10 @@ class TooltipAnchor extends Component {
     }
   }
 
+  componentWillUnmount() {
+    this.removeTooltip()
+  }
+
   referenceElementRef = (el) => {
     this.referenceElement = el
   }

--- a/packages/ui/src/tooltip/withTooltip.js
+++ b/packages/ui/src/tooltip/withTooltip.js
@@ -8,6 +8,22 @@ import { InnerPopper } from 'react-popper/lib/cjs/Popper'
 import { Arrow, Container } from './styles'
 
 
+const rectUnion = (rect1, rect2) => ({
+  bottom: Math.max(rect1.bottom, rect2.bottom),
+  left: Math.min(rect1.left, rect2.left),
+  right: Math.max(rect1.right, rect2.right),
+  top: Math.min(rect1.top, rect2.top),
+})
+
+
+const isPointInRect = (rect, point) => (
+  rect.bottom >= point.y
+  && rect.left <= point.x
+  && rect.right >= point.x
+  && rect.top <= point.y
+)
+
+
 class TooltipAnchor extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
@@ -24,16 +40,54 @@ class TooltipAnchor extends Component {
     this.removeTooltip()
   }
 
+  onMouseEnter = () => {
+    this.cancelTooltipRemoval()
+    this.renderTooltipInPortal()
+  }
+
+  onMouseLeave = (e) => {
+    // The user may want to interact with tooltip content, select tooltip text, etc.
+    // If the mouse is moving towards the tooltip element when it leaves the anchor element,
+    // allow some time for it to reach the tooltip before the tooltip is removed.
+    // The tooltip's removal will be canceled once the mouse enters the tooltip element.
+
+    // Approximate "is mouse moving towards tooltip" by checking if the mouse is contained
+    // in the union of the bounding boxes of the tooltip and anchor elements.
+    const tooltipBounds = this.containerElement.firstChild.getBoundingClientRect()
+    const anchorBounds = this.referenceElement.getBoundingClientRect()
+    const totalBounds = rectUnion(tooltipBounds, anchorBounds)
+    const mouseLocation = { x: e.clientX, y: e.clientY }
+
+    if (isPointInRect(totalBounds, mouseLocation)) {
+      this.scheduleTooltipRemoval()
+    } else {
+      this.removeTooltip()
+    }
+  }
+
   referenceElementRef = (el) => {
     this.referenceElement = el
   }
 
-  removeTooltip = () => {
+  removeTooltip() {
+    this.cancelTooltipRemoval()
     if (this.containerElement) {
       ReactDOM.unmountComponentAtNode(this.containerElement)
       document.body.removeChild(this.containerElement)
       this.containerElement = null
     }
+  }
+
+  cancelTooltipRemoval() {
+    if (this.removeTooltipTimeout) {
+      clearTimeout(this.removeTooltipTimeout)
+      this.removeTooltipTimeout = null
+    }
+  }
+
+  scheduleTooltipRemoval() {
+    this.cancelTooltipRemoval()
+    this.removeTooltipTimeout = setTimeout(() => this.removeTooltip(), 100)
   }
 
   renderTooltipContent = ({ ref, style, placement, arrowProps }) => {
@@ -45,14 +99,20 @@ class TooltipAnchor extends Component {
     } = this.props
 
     return (
-      <Container data-placement={placement} innerRef={ref} style={style}>
+      <Container
+        data-placement={placement}
+        innerRef={ref}
+        onMouseEnter={this.onMouseEnter}
+        onMouseLeave={this.onMouseLeave}
+        style={style}
+      >
         <TooltipComponent {...otherProps} />
         <Arrow data-placement={placement} innerRef={arrowProps.ref} style={arrowProps.style} />
       </Container>
     )
   }
 
-  renderTooltipInPortal = () => {
+  renderTooltipInPortal() {
     if (!this.containerElement) {
       this.containerElement = document.createElement('div')
       document.body.appendChild(this.containerElement)
@@ -78,8 +138,8 @@ class TooltipAnchor extends Component {
     return React.cloneElement(
       React.Children.only(this.props.children),
       {
-        onMouseEnter: this.renderTooltipInPortal,
-        onMouseLeave: this.removeTooltip,
+        onMouseEnter: this.onMouseEnter,
+        onMouseLeave: this.onMouseLeave,
         ref: this.referenceElementRef,
       }
     )


### PR DESCRIPTION
One of the requirements for the ClinVar track is showing a link to NCBI's website in a tooltip shown when hovering over a variant in the track.

Currently, tooltips are immediately removed when the mouse leaves the tooltip's anchor element. Thus, any link in a tooltip would be impossible to click because moving the mouse over the link would remove the tooltip and with it, the link.

This change keeps the tooltip visible while the mouse is over it. This allows putting interactive elements (such as links) in tooltips and allows users to select text shown in tooltips. 