### PR TITLE
Show label when canonical transcript is selected

### DIFF
--- a/projects/gnomad/src/GenePage/GeneInfo.js
+++ b/projects/gnomad/src/GenePage/GeneInfo.js
@@ -93,7 +93,8 @@ const GeneInfo = ({
                 target="_blank"
                 href={`http://www.ensembl.org/Homo_sapiens/Gene/Summary?g=${currentTranscript}`}
               >
-                {currentTranscript || `${canonical_transcript} (canonical)`}
+                {currentTranscript || canonical_transcript}
+                {(currentTranscript === null || currentTranscript === canonical_transcript) && ' (canonical)'}
               </a>
             </GeneAttributeValue>
             <GeneAttributeValue>


### PR DESCRIPTION
Currently, when viewing the gene page with no transcript selected, the transcript ID in the gene attributes section is labeled with "(canonical)". However, if the canonical transcript is selected, that label is not shown.

<img width="518" alt="screen shot 2018-07-16 at 4 57 37 pm" src="https://user-images.githubusercontent.com/1156625/42783562-62a7b526-891a-11e8-8d70-808ea75687e4.png">
