### PR TITLE
Restyle variant search input

### DIFF
--- a/packages/ui/src/search/simpleSearch.js
+++ b/packages/ui/src/search/simpleSearch.js
@@ -4,26 +4,43 @@ import React, { Component } from 'react'
 import styled from 'styled-components'
 
 const SearchWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
   font-size: 14px;
-  align-items: center;
+  position: relative;
+  width: 210px;
 `
 
 const SearchInput = styled.input`
-  height: 25px;
-  width: 210px;
-  border: 0;
-  border-bottom: 1px solid #000;
-  background-color: transparent;
-  text-indent: 5px;
-  -webkit-transition: width 0.4s ease-in-out;
+  appearance: none;
+  background: none;
+  border-color: #000;
+  border-style: solid;
+  border-width: 0 0 1px 0;
+  box-sizing: border-box;
+  padding: 0.25em 0.75em;
   transition: width 0.4s ease-in-out;
+  width: 100%;
+
+  &:focus {
+    border-color: rgb(70, 130, 180);
+    box-shadow: 0 0.3em 0.2em -0.2em rgba(70, 130, 180, 0.5);
+    padding-right: 1.75em;
+  }
 `
 
 const ClearSearchButton = styled.button`
-  margin-left: 5px;
-  height: 20px;
+  appearance: none;
+  background: none;
+  border: none;
+  box-sizing: border-box;
+  cursor: pointer;
+  height: 1.5em;
+  position: absolute;
+  right: 0;
+  top: 0;
+
+  &:active, &:hover {
+    color: rgb(40, 94, 142);
+  }
 `
 
 const SEARCH_KEYBOARD_SHORTCUTS = ['command+f', 'meta+s']
@@ -87,10 +104,13 @@ export class Search extends Component {
           type="text"
           value={this.state.value}
         />
-        <ClearSearchButton
-          onClick={this.onClear}
-          type="button"
-        >Clear</ClearSearchButton>
+        {this.state.value && (
+          <ClearSearchButton
+            aria-label="Clear"
+            onClick={this.onClear}
+            type="button"
+          >&times;</ClearSearchButton>
+        )}
       </SearchWrapper>
     )
   }

--- a/packages/ui/src/search/simpleSearch.js
+++ b/packages/ui/src/search/simpleSearch.js
@@ -89,6 +89,12 @@ export class Search extends Component {
     this.props.onChange('')
   }
 
+  onKeyDown = (e) => {
+    if (e.key === 'Escape') {
+      this.onClear()
+    }
+  }
+
   inputRef = (el) => {
     this.input = el
   }
@@ -99,6 +105,7 @@ export class Search extends Component {
         <SearchInput
           autoComplete="off"
           onChange={this.onChange}
+          onKeyDown={this.onKeyDown}
           placeholder={this.props.placeholder}
           innerRef={this.inputRef}
           type="text"


### PR DESCRIPTION
Style variant search input more like a default search input, with an "X" button that appears when a query is entered. Also handle pressing the escape key to clear the search query as the default search control does.

## Before

Default
<img width="290" alt="screen shot 2018-07-16 at 4 43 54 pm" src="https://user-images.githubusercontent.com/1156625/42783612-897357d2-891a-11e8-8ae9-83c8f2601afa.png">

Focused
<img width="290" alt="screen shot 2018-07-16 at 4 43 57 pm" src="https://user-images.githubusercontent.com/1156625/42783614-89807516-891a-11e8-8c9f-3e539e131e95.png">

With search query
<img width="286" alt="screen shot 2018-07-16 at 4 44 02 pm" src="https://user-images.githubusercontent.com/1156625/42783615-898d3c9c-891a-11e8-92df-486219d8fbd9.png">

## After

Default
<img width="257" alt="screen shot 2018-07-16 at 4 42 45 pm" src="https://user-images.githubusercontent.com/1156625/42783622-8d120168-891a-11e8-9a9b-ede9a8e3e6f8.png">

Focused
<img width="254" alt="screen shot 2018-07-16 at 4 42 50 pm" src="https://user-images.githubusercontent.com/1156625/42783623-8d1ec57e-891a-11e8-906c-3ee28a9f6a18.png">

With search query
<img width="243" alt="screen shot 2018-07-16 at 4 42 54 pm" src="https://user-images.githubusercontent.com/1156625/42783624-8d28ba20-891a-11e8-90ef-e8fff097084e.png">
