### PR TITLE
Fix link to Ensembl transcript

### DIFF
--- a/projects/gnomad/src/GenePage/GeneInfo.js
+++ b/projects/gnomad/src/GenePage/GeneInfo.js
@@ -91,7 +91,7 @@ const GeneInfo = ({
             <GeneAttributeValue>
               <a
                 target="_blank"
-                href={`http://www.ensembl.org/Homo_sapiens/Gene/Summary?g=${currentTranscript}`}
+                href={`http://www.ensembl.org/Homo_sapiens/Transcript/Summary?t=${currentTranscript || canonical_transcript}`}
               >
                 {currentTranscript || `${canonical_transcript} (canonical)`}
               </a>


### PR DESCRIPTION
The link to the current transcript in Ensembl is actually pointed at Ensembl's gene page. Since it passes the current transcript ID (which is null when no transcript is selected) as a gene ID, this always results in either an error or a gene not found page.

<img width="518" alt="screen shot 2018-07-16 at 4 57 37 pm" src="https://user-images.githubusercontent.com/1156625/42783915-75bf91be-891b-11e8-8a96-3378398ebbf6.png">
