### PR TITLE
Make RegionHoc consistent with GenePageHoc

### DIFF
--- a/packages/region/package.json
+++ b/packages/region/package.json
@@ -8,6 +8,8 @@
   ],
   "dependencies": {
     "@broad/redux-genes": "*",
+    "@broad/redux-variants": "*",
+    "@broad/ui": "*",
     "@broad/utilities": "*",
     "react-apollo": "^2.0.1",
     "react-redux": "^5.0.6"

--- a/packages/region/src/RegionHoc.js
+++ b/packages/region/src/RegionHoc.js
@@ -98,6 +98,15 @@ export const RegionHoc = (
         return regionFetchFunction(regionId)
           .then((regionData) => {
             thunkDispatch(regionActions.receiveRegionData(regionId, regionData))
+
+            const defaultVariantFilter = (regionData.stop - regionData.start) > 50000
+              ? 'lof'
+              : 'all'
+
+            // Reset variant filters when loading a new region
+            thunkDispatch(variantActions.searchVariantsRaw(''))
+            thunkDispatch(variantActions.setVariantFilter(defaultVariantFilter))
+
             return regionData
           })
       })

--- a/packages/region/src/index.js
+++ b/packages/region/src/index.js
@@ -16,9 +16,7 @@ export {
   attributeConfig,
 } from './regionViewerStyles'
 
-export {
-  default as RegionHoc,
-} from './RegionHoc'
+export { RegionHoc } from './RegionHoc'
 
 export {
   default as RegionViewer,

--- a/packages/region/src/regionRedux.js
+++ b/packages/region/src/regionRedux.js
@@ -27,43 +27,6 @@ export const actions = {
     regionId,
     regionData: Immutable.fromJS(regionData),
   }),
-
-  fetchPageDataByRegionName (regionId, regionFetchFunction) {
-    return (dispatch) => {
-      dispatch(actions.requestRegionData(regionId))
-      regionFetchFunction(regionId)
-        .then((regionData) => {
-          dispatch(actions.receiveRegionData(regionId, regionData))
-        })
-    }
-  },
-
-  shouldFetchRegion (state, currentRegion) {
-    const region = state.regions.allRegionNames[currentRegion]
-    if (!region) {
-      return true
-    }
-    if (state.regions.isFetching) {
-      return false
-    }
-    console.log('fetching')
-    return false
-  },
-
-  fetchRegionIfNeeded (currentRegion, match, regionFetchFunction) {
-    if (match) {
-      if (match.params.regionId) {
-        return (dispatch) => {
-          dispatch(actions.setCurrentRegion(match.params.regionId))
-        }
-      }
-    }
-    return (dispatch, getState) => {  // eslint-disable-line
-      if (actions.shouldFetchRegion(getState(), currentRegion)) {
-        return dispatch(actions.fetchPageDataByRegionName(currentRegion, regionFetchFunction))
-      }
-    }
-  }
 }
 
 export default function createRegionReducer({

--- a/projects/gnomad/src/RegionPage/RegionViewer.js
+++ b/projects/gnomad/src/RegionPage/RegionViewer.js
@@ -1,13 +1,14 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
+import { compose } from 'redux'
 
 import CoverageTrack from '@broad/track-coverage'
 import { VariantAlleleFrequencyTrack } from '@broad/track-variant'
 import StackedBarTrack from '@broad/track-stacked-bar'
 import { GenesTrack } from '@broad/track-genes'
 
-import { actions as geneActions } from '@broad/redux-genes'
 import { screenSize } from '@broad/ui'
 import { RegionViewer, regionData, attributeConfig } from '@broad/region'
 import { NavigatorTrackConnected } from '@broad/track-navigator'
@@ -23,8 +24,8 @@ import { getCoverageConfig } from '../GenePage/RegionViewer'
 const RegionViewerConnected = ({
   regionData,
   allVariants,
+  history,
   selectedVariantDataset,
-  onGeneClick,
   screenSize,
   variantFilter,
 }) => {
@@ -103,11 +104,17 @@ const RegionViewerConnected = ({
           yMax={110}
           totalBp={totalBp}
         />
-        <GenesTrack onGeneClick={onGeneClick} genes={genes} />
+
+        <GenesTrack
+          genes={genes}
+          onGeneClick={geneName => history.push(`/gene/${geneName}`)}
+        />
+
         <VariantAlleleFrequencyTrack
           title={`${datasetTranslations[selectedVariantDataset]}\n${consequenceTranslations[variantFilter]}\n(${allVariants.size})`}
           variants={variantsReversed.toJS()}
         />
+
         {showStacked &&
           <StackedBarTrack height={150} data={buckets} />
         }
@@ -119,24 +126,24 @@ const RegionViewerConnected = ({
 RegionViewerConnected.propTypes = {
   regionData: PropTypes.object.isRequired,
   allVariants: PropTypes.any.isRequired,
-  onGeneClick: PropTypes.func,
+  history: PropTypes.object.isRequired,
   selectedVariantDataset: PropTypes.string.isRequired,
   screenSize: PropTypes.object.isRequired,
 }
 RegionViewerConnected.defaultProps = {
   coverageStyle: null,
-  onGeneClick: () => {},
 }
 
-export default connect(
-  state => ({
-    regionData: regionData(state),
-    allVariants: finalFilteredVariants(state),
-    selectedVariantDataset: selectedVariantDataset(state),
-    screenSize: screenSize(state),
-    variantFilter: variantFilter(state),
-  }),
-  dispatch => ({
-    onGeneClick: geneName => dispatch(geneActions.setCurrentGene(geneName)),
-  })
+
+export default compose(
+  withRouter,
+  connect(
+    state => ({
+      regionData: regionData(state),
+      allVariants: finalFilteredVariants(state),
+      selectedVariantDataset: selectedVariantDataset(state),
+      screenSize: screenSize(state),
+      variantFilter: variantFilter(state),
+    })
+  )
 )(RegionViewerConnected)

--- a/projects/gnomad/src/RegionPage/index.js
+++ b/projects/gnomad/src/RegionPage/index.js
@@ -1,25 +1,16 @@
-/* eslint-disable import/no-extraneous-dependencies */
-/* eslint-disable space-before-function-paren */
-/* eslint-disable no-shadow */
-/* eslint-disable comma-dangle */
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/extensions */
-/* eslint-disable no-case-declarations */
-
 import React from 'react'
-import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { withRouter, Route } from 'react-router-dom'
 
 import { RegionHoc } from '@broad/region'
 import { VariantTable } from '@broad/table'
 
-import RegionInfo from './RegionInfo'
 import Settings from '../Settings'
+import tableConfig from '../tableConfig'
+
+import { fetchRegion } from './fetch'
+import RegionInfo from './RegionInfo'
 import RegionViewer from './RegionViewer'
 
-import tableConfig from '../tableConfig'
-import { fetchRegion } from './fetch'
 
 const RegionPageWrapper = styled.div`
   display: flex;
@@ -62,13 +53,8 @@ const TableSection = styled.div`
   }
 `
 
-const RegionPage = ({
-  regionData,
-  isFetching,
-}) => {
-  if (isFetching || !regionData) {
-    return <div>Loading...!</div>
-  }
+
+const RegionPage = () => {
   return (
     <RegionPageWrapper>
       <Summary>
@@ -77,22 +63,10 @@ const RegionPage = ({
       <RegionViewer coverageStyle={'new'} />
       <Settings />
       <TableSection>
-        <Route
-          exact
-          path="/region/:regionId"
-          render={() => <VariantTable tableConfig={tableConfig} />}
-        />
+        <VariantTable tableConfig={tableConfig} />
       </TableSection>
     </RegionPageWrapper>
   )
 }
 
-RegionPage.propTypes = {
-  regionData: PropTypes.object,
-  isFetching: PropTypes.bool.isRequired,
-}
-RegionPage.defaultProps = {
-  regionData: null,
-}
-
-export default withRouter(RegionHoc(RegionPage, fetchRegion, 'gnomadCombinedVariants'))
+export default RegionHoc(RegionPage, fetchRegion, 'gnomadCombinedVariants')

--- a/projects/gnomad/src/routes.js
+++ b/projects/gnomad/src/routes.js
@@ -38,7 +38,11 @@ const App = () => (
           path="/gene/:gene"
           render={({ match }) => <GenePage geneName={match.params.gene} />}
         />
-        <Route exact path="/region/:regionId" component={RegionPage} />
+        <Route
+          exact
+          path="/region/:regionId"
+          render={({ match }) => <RegionPage regionId={match.params.regionId} />}
+        />
       </Switch>
       {/* <Route path="/variant/:variant" component={GenePage} /> */}
       {/* <Route path="/rsid/:rsid" component={GenePage} /> */}


### PR DESCRIPTION
#106 heavily refactored the gene page higher order component. This does the same to the region page HOC to make it consistent with the gene page.

* Move loading state to RegionPage and add error state. This saves us from having to reimplement loading spinners and error messages in each project that uses gene page. This makes the loading UI consistent between region and gene pages.
* Previously, RegionPage would push to history when the current region in Redux changed. Having routing depend on a particular component being mounted when dispatching an action is error prone (it only works when viewing the gene page). The RegionViewer on the region page previously relied on this behavior. This changes RegionViewer to push the URL itself instead of going through Redux.