### PR TITLE
Change chrom arg of region query from int to string

### DIFF
--- a/packages/api/src/schema/index.js
+++ b/packages/api/src/schema/index.js
@@ -3,7 +3,6 @@ import {
   GraphQLObjectType,
   GraphQLFloat,
   GraphQLString,
-  GraphQLInt,
   GraphQLNonNull,
 } from 'graphql'
 
@@ -80,7 +79,7 @@ The fields below allow for different ways to look up gnomAD data. Click on the t
       args: {
         start: { type: new GraphQLNonNull(GraphQLFloat) },
         stop: { type: new GraphQLNonNull(GraphQLFloat) },
-        chrom: { type: new GraphQLNonNull(GraphQLInt) },
+        chrom: { type: new GraphQLNonNull(GraphQLString) },
       },
       resolve: (obj, args) => ({
         start: args.start,

--- a/packages/api/src/schema/types/region.js
+++ b/packages/api/src/schema/types/region.js
@@ -38,7 +38,7 @@ const regionType = new GraphQLObjectType({
     stop: { type: GraphQLFloat },
     xstart: { type: GraphQLFloat },
     xstop: { type: GraphQLFloat },
-    chrom: { type: GraphQLInt },
+    chrom: { type: GraphQLString },
     regionSize: { type: GraphQLInt },
     genes: {
       type: new GraphQLList(geneType),

--- a/projects/gnomad/src/RegionPage/fetch.js
+++ b/projects/gnomad/src/RegionPage/fetch.js
@@ -8,7 +8,7 @@ const API_URL = process.env.GNOMAD_API_URL
 export const fetchRegion = (regionId, url = API_URL) => {
   const [chrom, start, stop] = regionId.split('-')
   const query = `{
-  region(start: ${Number(start)}, stop: ${Number(stop)}, chrom: ${Number(chrom)}) {
+  region(start: ${Number(start)}, stop: ${Number(stop)}, chrom: "${chrom}") {
     start
     stop
     xstop


### PR DESCRIPTION
X and Y chromosomes are not numeric, so the API currently rejects queries for regions in those chromosomes.

Fixes #54.