### PR TITLE
Always allow all variant filters

### DIFF
--- a/projects/gnomad/src/RegionPage/RegionViewer.js
+++ b/projects/gnomad/src/RegionPage/RegionViewer.js
@@ -40,12 +40,6 @@ const RegionViewerConnected = ({
     gnomad_consequence_buckets: { buckets },
   } = regionData.toJS()
 
-  let partialFetch
-  if ((regionData.get('stop') - regionData.get('start')) > 50000) {
-    partialFetch = 'lof'
-    variantFilter = variantFilter === 'all' ? partialFetch : variantFilter  // eslint-disable-line
-  }
-
   const variantsReversed = allVariants.reverse()
 
   const coverageConfig = getCoverageConfig(

--- a/projects/gnomad/src/Settings.js
+++ b/projects/gnomad/src/Settings.js
@@ -13,13 +13,11 @@ import {
   ClassicExacButtonFirst,
   ClassicExacButtonLast,
   ClassicExacButtonGroup,
-
   SettingsContainer,
   MenusContainer,
   SearchContainer,
   DataSelectionGroup,
   DataSelectionContainer,
-
   Search,
 } from '@broad/ui'
 
@@ -72,20 +70,20 @@ const GeneSettings = ({
           </DataSelectionContainer>
         </DataSelectionGroup>
         <DataSelectionGroup>
-          <form>
-            <div>
+          <span>
+            <label htmlFor="qcFilter">
               <input
                 id="qcFilter"
                 type="checkbox"
                 checked={!variantQcFilter}
-                onChange={event => toggleVariantQcFilter()}
+                style={{ marginRight: '5px' }}
+                onChange={toggleVariantQcFilter}
               />
-              <label style={{ marginLeft: '5px' }} htmlFor="qcFilter">
-                Include filtered variants
-              </label>
-              <QuestionMark topic={'include-filtered-variants'} display={'inline'} />
-            </div>
-          </form>
+              Include filtered variants
+            </label>
+            <QuestionMark topic={'include-filtered-variants'} display={'inline'} />
+          </span>
+
           <SearchContainer>
             <Search
               placeholder={'Search variant table'}

--- a/projects/gnomad/src/Settings.js
+++ b/projects/gnomad/src/Settings.js
@@ -1,17 +1,13 @@
 import React, { PropTypes } from 'react'
-import styled from 'styled-components'
 import { connect } from 'react-redux'
 
+import { QuestionMark } from '@broad/help'
 import {
   actions as variantActions,
   selectedVariantDataset,
   variantFilter,
   variantQcFilter,
-  variantSearchText,
 } from '@broad/redux-variants'
-
-import { actions as geneActions, exonPadding } from '@broad/redux-genes'
-
 import {
   ClassicExacButton,
   ClassicExacButtonFirst,
@@ -27,25 +23,16 @@ import {
   Search,
 } from '@broad/ui'
 
-import { QuestionMark } from '@broad/help'
 
 const GeneSettings = ({
-  exonPadding,
   selectedVariantDataset,
-  setExonPadding,
   searchVariants,
   setVariantFilter,
   variantFilter,
   setSelectedVariantDataset,
   toggleVariantQcFilter,
   variantQcFilter,
-  variantSearchText,
 }) => {
-  const setPadding = (event, newValue) => {
-    const padding = Math.floor(1000 * newValue)
-    setExonPadding(padding)
-  }
-
   return (
     <SettingsContainer>
       <MenusContainer>
@@ -113,26 +100,24 @@ const GeneSettings = ({
 }
 
 GeneSettings.propTypes = {
-  selectedVariantDataset: PropTypes.string.isRequired,
-  exonPadding: PropTypes.number.isRequired,
-  setExonPadding: PropTypes.func.isRequired,
   searchVariants: PropTypes.func.isRequired,
-  setVariantFilter: PropTypes.func.isRequired,
+  selectedVariantDataset: PropTypes.string.isRequired,
   setSelectedVariantDataset: PropTypes.func.isRequired,
+  setVariantFilter: PropTypes.func.isRequired,
+  toggleVariantQcFilter: PropTypes.func.isRequired,
+  variantFilter: PropTypes.string.isRequired,
+  variantQcFilter: PropTypes.bool.isRequired,
 }
 
 const mapStateToProps = (state) => {
   return {
-    exonPadding: exonPadding(state),
     selectedVariantDataset: selectedVariantDataset(state),
     variantQcFilter: variantQcFilter(state),
     variantFilter: variantFilter(state),
-    // variantSearchText: variantSearchText(state),
   }
 }
 const mapDispatchToProps = (dispatch) => {
   return {
-    setExonPadding: padding => dispatch(geneActions.setExonPadding(padding)),
     setVariantFilter: filter => dispatch(variantActions.setVariantFilter(filter)),
     searchVariants: searchText =>
       dispatch(variantActions.searchVariants(searchText)),

--- a/projects/gnomad/src/Settings.js
+++ b/projects/gnomad/src/Settings.js
@@ -46,34 +46,31 @@ const GeneSettings = ({
     setExonPadding(padding)
   }
 
-  const ClassicVariantCategoryButtonGroup = () => (
-    <ClassicExacButtonGroup>
-      <ClassicExacButtonFirst
-        isActive={variantFilter === 'all'}
-        onClick={() => setVariantFilter('all')}
-      >
-        All
-      </ClassicExacButtonFirst>
-      <ClassicExacButton
-        isActive={variantFilter === 'missenseOrLoF'}
-        onClick={() => setVariantFilter('missenseOrLoF')}
-      >
-        Missense + LoF
-      </ClassicExacButton>
-      <ClassicExacButtonLast
-        isActive={variantFilter === 'lof'}
-        onClick={() => setVariantFilter('lof')}
-      >
-        LoF
-      </ClassicExacButtonLast>
-    </ClassicExacButtonGroup>
-  )
-
   return (
     <SettingsContainer>
       <MenusContainer>
         <DataSelectionGroup>
-          <ClassicVariantCategoryButtonGroup />
+          <ClassicExacButtonGroup>
+            <ClassicExacButtonFirst
+              isActive={variantFilter === 'all'}
+              onClick={() => setVariantFilter('all')}
+            >
+              All
+            </ClassicExacButtonFirst>
+            <ClassicExacButton
+              isActive={variantFilter === 'missenseOrLoF'}
+              onClick={() => setVariantFilter('missenseOrLoF')}
+            >
+              Missense + LoF
+            </ClassicExacButton>
+            <ClassicExacButtonLast
+              isActive={variantFilter === 'lof'}
+              onClick={() => setVariantFilter('lof')}
+            >
+              LoF
+            </ClassicExacButtonLast>
+          </ClassicExacButtonGroup>
+
           <DataSelectionContainer>
             <select
               onChange={event => setSelectedVariantDataset(event.target.value)}

--- a/projects/gnomad/src/Settings.js
+++ b/projects/gnomad/src/Settings.js
@@ -10,8 +10,7 @@ import {
   variantSearchText,
 } from '@broad/redux-variants'
 
-import { actions as geneActions, geneData, exonPadding } from '@broad/redux-genes'
-import { regionData } from '@broad/region'
+import { actions as geneActions, exonPadding } from '@broad/redux-genes'
 
 import {
   ClassicExacButton,
@@ -41,41 +40,10 @@ const GeneSettings = ({
   toggleVariantQcFilter,
   variantQcFilter,
   variantSearchText,
-  geneData,
-  regionData,
 }) => {
   const setPadding = (event, newValue) => {
     const padding = Math.floor(1000 * newValue)
     setExonPadding(padding)
-  }
-  let partialFetch
-  if (regionData) {
-    if ((regionData.get('stop') - regionData.get('start')) > 50000) {
-      partialFetch = 'lof'
-      variantFilter = variantFilter === 'all' ? partialFetch : variantFilter  // eslint-disable-line
-    }
-  }
-
-  let totalBasePairs
-  if (geneData) {
-    const exons = geneData.getIn(['transcript', 'exons']).toJS()
-
-    const padding = 75
-    totalBasePairs = exons.filter(region => region.feature_type === 'CDS')
-      .reduce((acc, { start, stop }) => (acc + ((stop - start) + (padding * 2))), 0)
-  }
-
-  if (totalBasePairs > 100000) {
-    partialFetch = 'lof'
-    variantFilter = partialFetch  // eslint-disable-line
-  } else if (totalBasePairs > 40000) {
-    partialFetch = 'missenseOrLoF'
-    variantFilter = variantFilter === 'all' ? partialFetch : variantFilter  // eslint-disable-line
-  } else if (regionData) {
-    if ((regionData.get('stop') - regionData.get('start')) > 50000) {
-      partialFetch = 'lof'
-      variantFilter = variantFilter === 'all' ? partialFetch : variantFilter  // eslint-disable-line
-    }
   }
 
   const ClassicVariantCategoryButtonGroup = () => (
@@ -83,14 +51,12 @@ const GeneSettings = ({
       <ClassicExacButtonFirst
         isActive={variantFilter === 'all'}
         onClick={() => setVariantFilter('all')}
-        disabled={(partialFetch === 'lof' || partialFetch === 'missenseOrLoF')}
       >
         All
       </ClassicExacButtonFirst>
       <ClassicExacButton
         isActive={variantFilter === 'missenseOrLoF'}
         onClick={() => setVariantFilter('missenseOrLoF')}
-        disabled={(partialFetch === 'lof')}
       >
         Missense + LoF
       </ClassicExacButton>
@@ -165,8 +131,6 @@ const mapStateToProps = (state) => {
     variantQcFilter: variantQcFilter(state),
     variantFilter: variantFilter(state),
     // variantSearchText: variantSearchText(state),
-    geneData: geneData(state),
-    regionData: regionData(state),
   }
 }
 const mapDispatchToProps = (dispatch) => {


### PR DESCRIPTION
Currently, "All" or "Missense + LoF" consequences may be disabled for large genes/regions. This was necessary because the variant track was prohibitively slow to render with that many variants.

After #126, that is no longer the case so all consequence filters can be enabled all the time.


Also remove definition of ClassicVariantCategoryButtonGroup component from Settings' render function.

Resolves #31.