### PR TITLE
Remove redux-search

### DIFF
--- a/packages/gene-page/package.json
+++ b/packages/gene-page/package.json
@@ -29,7 +29,6 @@
     "immutable": "^3.8.1",
     "keymirror": "^0.1.1",
     "prop-types": "^15.5.10",
-    "redux-debounced": "^0.4.0",
-    "redux-search": "^2.3.3"
+    "redux-debounced": "^0.4.0"
   }
 }

--- a/packages/gene-page/src/store/store.js
+++ b/packages/gene-page/src/store/store.js
@@ -9,7 +9,6 @@ import thunk from 'redux-thunk'
 import throttle from 'redux-throttle'
 import createDebounce from 'redux-debounced'
 import { createLogger } from 'redux-logger'
-import { reduxSearch, reducer as searchReducer } from 'redux-search'
 import { createVariantReducer } from '@broad/redux-variants'
 import { createGeneReducer } from '@broad/redux-genes'
 import { createRegionReducer } from '@broad/region'
@@ -35,7 +34,6 @@ export default function createGenePageStore(appSettings, appReducers) {
   }
   const rootReducer = combineReducers({
     genes: createGeneReducer(appSettings),
-    search: searchReducer,
     variants: createVariantReducer(appSettings),
     regions: createRegionReducer(appSettings),
     help: createHelpReducer(appSettings.docs),
@@ -45,13 +43,7 @@ export default function createGenePageStore(appSettings, appReducers) {
   })
 
   const finalCreateStore = compose(
-    applyMiddleware(...middlewares),
-    reduxSearch({
-      resourceIndexes: {
-        variants: appSettings.searchIndexes,
-      },
-      resourceSelector: appSettings.searchResourceSelector,
-    })
+    applyMiddleware(...middlewares)
   )(createStore)
 
   return finalCreateStore(rootReducer)

--- a/packages/gene-page/src/tests/test.js
+++ b/packages/gene-page/src/tests/test.js
@@ -14,7 +14,10 @@ const sum = (oldValue, newValue) => oldValue + newValue
 const concat = (oldValue, newValue) => oldValue.concat(newValue)
 
 const appSettings = {
-  searchIndexes: ['variant_id'],
+  variantSearchPredicate(variant, query) {
+    return variant.get('variant_id').toLowerCase().includes(query)
+  },
+  variantSearchFields: ['variant_id'],
   logger: false,
   projectDefaults: {
     startingGene: 'ARSF',

--- a/packages/redux-genes/src/GenePageHoc.js
+++ b/packages/redux-genes/src/GenePageHoc.js
@@ -122,7 +122,7 @@ const mapDispatchToProps = geneFetchFunction => dispatch => ({
           thunkDispatch(geneActions.receiveGeneData(geneName, geneData))
 
           // Reset variant filters when loading a new gene
-          thunkDispatch(variantActions.searchVariantsRaw(''))
+          thunkDispatch(variantActions.searchVariants(''))
 
           let defaultVariantFilter = 'all'
           if (geneData) {

--- a/packages/redux-variants/index.js
+++ b/packages/redux-variants/index.js
@@ -10,9 +10,7 @@ export {
   variantFilter,
   variantQcFilter,
   variantDeNovoFilter,
-  variantSearchText,
-  filteredIdList,
+  variantSearchQuery,
   finalFilteredVariants,
-  finalFilteredVariantsCount,
   focusedVariant,
 } from './variants'

--- a/packages/redux-variants/package.json
+++ b/packages/redux-variants/package.json
@@ -17,7 +17,6 @@
     "@broad/utilities": "*",
     "keymirror": "^0.1.1",
     "immutable": "^4.0.0-rc.9",
-    "redux-search": "^2.3.3",
     "reselect": "^3.0.1"
   }
 }

--- a/packages/redux-variants/testStore.js
+++ b/packages/redux-variants/testStore.js
@@ -15,7 +15,6 @@ import thunk from 'redux-thunk'
 import throttle from 'redux-throttle'
 import createDebounce from 'redux-debounced'
 import { createLogger } from 'redux-logger'
-import { reduxSearch, reducer as searchReducer } from 'redux-search'
 
 
 import createVariantReducer, {
@@ -42,7 +41,6 @@ export default function createGenePageStore(appSettings, appReducers) {
   const rootReducer = combineReducers({
     active: createActiveReducer(appSettings),
     genes: createGeneReducer(appSettings),
-    search: searchReducer,
     variants: createVariantReducer(appSettings),
     regions: createRegionReducer(appSettings),
     help: createHelpReducer(appSettings.docs),
@@ -50,13 +48,7 @@ export default function createGenePageStore(appSettings, appReducers) {
   })
 
   const finalCreateStore = compose(
-    applyMiddleware(...middlewares),
-    reduxSearch({
-      resourceIndexes: {
-        variants: appSettings.searchIndexes,
-      },
-      resourceSelector: appSettings.searchResourceSelector,
-    }),
+    applyMiddleware(...middlewares)
   )(createStore)
 
   return finalCreateStore(rootReducer)

--- a/packages/region/src/RegionHoc.js
+++ b/packages/region/src/RegionHoc.js
@@ -104,7 +104,7 @@ export const RegionHoc = (
               : 'all'
 
             // Reset variant filters when loading a new region
-            thunkDispatch(variantActions.searchVariantsRaw(''))
+            thunkDispatch(variantActions.searchVariants(''))
             thunkDispatch(variantActions.setVariantFilter(defaultVariantFilter))
 
             return regionData

--- a/packages/table/src/Table.js
+++ b/packages/table/src/Table.js
@@ -607,17 +607,7 @@ const TableHeaders = ({ title, tableConfig, showIndex }) => (
   </div>
 )
 
-const NoVariants = styled.div`
-  display: flex;
-  align-items: center;
-  height: ${props => props.height}px;
-  width: ${props => props.width}px;
-  justify-content: center;
-  font-weight: bold;
-  font-size: 20px;
-  border: 1px dashed gray;
-  margin-top: 20px;
-`
+
 
 const Table = ({
   title,
@@ -634,12 +624,7 @@ const Table = ({
   onScroll,
   searchText,
   width,
-  filteredIdList,
 }) => {
-  if (searchText !== '' && filteredIdList.size === 0) {
-    return <NoVariants width={width} height={height}>No variants found</NoVariants>
-  }
-
   const isRowLoaded = ({ index }) => Boolean(getRowData(tableData, index))
 
   const rowRenderer = tableRowRenderer(

--- a/packages/table/src/VariantTable.js
+++ b/packages/table/src/VariantTable.js
@@ -8,14 +8,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import styled from 'styled-components'
 
 import { actions as tableActions, currentTableIndex } from '@broad/table'
 import { screenSize } from '@broad/ui'
 
 import {
   actions as variantActions,
-  variantSearchText,
-  filteredIdList,
+  variantSearchQuery,
   finalFilteredVariants,
   finalFilteredVariantsCount,
 } from '@broad/redux-variants'
@@ -25,6 +25,20 @@ import { currentChromosome as regionChromosome } from '@broad/region'
 
 import { Table } from './index'
 
+
+const NoVariants = styled.div`
+  display: flex;
+  align-items: center;
+  height: ${props => props.height}px;
+  width: ${props => props.width}px;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 20px;
+  border: 1px dashed gray;
+  margin-top: 20px;
+`
+
+
 const VariantTable = ({
   variants,
   setVariantSort,
@@ -33,15 +47,19 @@ const VariantTable = ({
   setCurrentTableScrollData,
   currentChromosome,
   tablePosition,
-  searchText,
+  searchQuery,
   title,
   height,
   tableConfig,
   screenSize,
-  filteredIdList,
 }) => {
   const scrollBarWidth = 40
   const tableWidth = (screenSize.width * 0.8) + scrollBarWidth
+
+  if (variants.size === 0) {
+    return <NoVariants height={500} width={tableWidth}>No variants found</NoVariants>
+  }
+
   const tConfig = tableConfig(setVariantSort, tableWidth, currentChromosome)
 
   return (
@@ -59,8 +77,7 @@ const VariantTable = ({
         onRowHover={setHoveredVariant}
         scrollToRow={tablePosition}
         onScroll={setCurrentTableScrollData}
-        searchText={searchText}
-        filteredIdList={filteredIdList}
+        searchText={searchQuery}
       />
     </div>
   )
@@ -72,12 +89,11 @@ VariantTable.propTypes = {
   setFocusedVariant: PropTypes.func.isRequired,
   setCurrentTableScrollData: PropTypes.func.isRequired,
   tablePosition: PropTypes.number.isRequired,
-  searchText: PropTypes.string.isRequired,
+  searchQuery: PropTypes.string.isRequired,
   title: PropTypes.string,
   height: PropTypes.number,
   tableConfig: PropTypes.func.isRequired,
   screenSize: PropTypes.object.isRequired,
-  filteredIdList: PropTypes.any.isRequired,
   // setVisibleInTable: PropTypes.func.isRequired,
 }
 
@@ -88,11 +104,9 @@ VariantTable.defaultProps = {
 const mapStateToProps = (state) => {
   return {
     variants: finalFilteredVariants(state),
-    variantCount: finalFilteredVariantsCount(state),
     tablePosition: currentTableIndex(state),
-    searchText: variantSearchText(state),
+    searchQuery: variantSearchQuery(state),
     screenSize: screenSize(state),
-    filteredIdList: filteredIdList(state),
     currentChromosome: geneChromosome(state) || regionChromosome(state),
   }
 }

--- a/packages/table/src/VariantTableApollo.js
+++ b/packages/table/src/VariantTableApollo.js
@@ -201,7 +201,6 @@ const VariantTable = ({
         // scrollToRow={tablePosition}
         onScroll={() => {}}
         searchText={''}
-        // filteredIdList={filteredIdList}
       />
     </Wrapper>
   )

--- a/packages/table/src/example/VariantTableRedux.example.js
+++ b/packages/table/src/example/VariantTableRedux.example.js
@@ -24,9 +24,14 @@ const sum = (oldValue, newValue) => oldValue + newValue
 const concat = (oldValue, newValue) => oldValue.concat(newValue)
 
 const appSettings = {
-  searchIndexes: ['variant_id', 'rsid', 'consequence', 'hgvsp', 'hgvsc'],
-  searchResourceSelector: (resourceName, state) => {
-    return state.variants.searchIndexed
+  variantSearchPredicate(variant, query) {
+    return (
+      variant.get('variant_id').toLowerCase().includes(query)
+      || variant.get('rsid').toLowerCase().includes(query)
+      || variant.get('consequence').toLowerCase().includes(query)
+      || variant.get('hgvsp').toLowerCase().includes(query)
+      || variant.get('hgvsc').toLowerCase().includes(query)
+    )
   },
   logger: true,
   projectDefaults: {

--- a/projects/gnomad/src/Main.js
+++ b/projects/gnomad/src/Main.js
@@ -13,9 +13,14 @@ const sum = (oldValue, newValue) => oldValue + newValue
 const concat = (oldValue, newValue) => oldValue.concat(newValue)
 
 const appSettings = {
-  searchIndexes: ['variant_id', 'rsid', 'consequence', 'hgvsp', 'hgvsc'],
-  searchResourceSelector: (resourceName, state) => {
-    return state.variants.searchIndexed
+  variantSearchPredicate(variant, query) {
+    return (
+      variant.get('variant_id').toLowerCase().includes(query)
+      || (variant.get('rsid') || '').toLowerCase().includes(query)
+      || (variant.get('consequence') || '').toLowerCase().includes(query)
+      || (variant.get('hgvsp') || '').toLowerCase().includes(query)
+      || (variant.get('hgvsc') || '').toLowerCase().includes(query)
+    )
   },
   logger: true,
   docs: {

--- a/projects/schizophrenia/src/GeneResults.js
+++ b/projects/schizophrenia/src/GeneResults.js
@@ -173,7 +173,6 @@ class SchizophreniaGeneResults extends PureComponent {
             onRowHover={() => {}}
             onScroll={() => {}}
             searchText={this.state.searchText}
-            filteredIdList={new List(['test'])}
           />
         )}
       </GenePage>

--- a/projects/schizophrenia/src/Main.js
+++ b/projects/schizophrenia/src/Main.js
@@ -26,22 +26,14 @@ const consequencePresentation = {
 }
 
 const appSettings = {
-  searchIndexes: ({ resources, indexDocument, state }) => {
-    resources.forEach(variant => {
-      indexDocument(variant.get('id'), variant.get('variant_id'))
-      if (variant.get('hgvsc_canonical')) {
-        indexDocument(variant.get('id'), variant.get('hgvsc_canonical'))
-      }
-      if (variant.get('hgvsp_canonical')) {
-        indexDocument(variant.get('id'), variant.get('hgvsp_canonical'))
-      }
-      if (variant.get('consequence')) {
-        indexDocument(variant.get('id'), consequencePresentation[variant.get('consequence')])
-      }
-    })
-  },
-  searchResourceSelector: (resourceName, state) => {
-    return state.variants.searchIndexed
+  variantSearchPredicate(variant, query) {
+    const consequenceCategoryLabel = consequencePresentation[variant.get('consequence')] || ''
+    return (
+      variant.get('variant_id').toLowerCase().includes(query)
+      || (variant.get('hgvsc_canonical') || '').toLowerCase().includes(query)
+      || (variant.get('hgvsp_canonical') || '').toLowerCase().includes(query)
+      || consequenceCategoryLabel.includes(query)
+    )
   },
   logger: true,
   docs: {

--- a/projects/variantfx/src/GenePage/FetchHoc.js
+++ b/projects/variantfx/src/GenePage/FetchHoc.js
@@ -61,7 +61,7 @@ const mapDispatchToProps = geneFetchFunction => (dispatch) => {
       geneActions.fetchGeneIfNeeded(currentGene, match, geneFetchFunction)
     ),
     resetSearchVariants: () => dispatch(
-      variantActions.searchVariantsRaw('')
+      variantActions.searchVariants('')
     ),
   }
 }

--- a/projects/variantfx/src/Main.js
+++ b/projects/variantfx/src/Main.js
@@ -7,9 +7,12 @@ import { variantfx } from './redux'
 import App from './routes'
 
 const appSettings = {
-  searchIndexes: ['variant_id', 'HGVSc', 'Consequence'],
-  searchResourceSelector: (resourceName, state) => {
-    return state.variants.searchIndexed
+  variantSearchPredicate(variant, query) {
+    return (
+      variant.get('variant_id').toLowerCase().includes(query)
+      || (variant.get('HGVSc') || '').toLowerCase().includes(query)
+      || (variant.get('Consequence') || '').toLowerCase().includes(query)
+    )
   },
   logger: true,
   docs: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,7 +1547,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@6.x.x, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -4207,10 +4207,6 @@ flexbuffer@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/flexbuffer/-/flexbuffer-0.0.6.tgz#039fdf23f8823e440c38f3277e6fef1174215b30"
 
-flow-bin@^0.50.0:
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.50.0.tgz#d4cdb2430dee1a3599f0eb6fe551146e3027256a"
-
 focus-trap-react@^3.0.4:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-3.1.2.tgz#4dd021ccd028bbd3321147d132cdf7585d6d1394"
@@ -5584,13 +5580,6 @@ js-base64@^2.1.9:
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-
-js-worker-search@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/js-worker-search/-/js-worker-search-1.2.1.tgz#c3a8b826ef90d1ed40ed4d202c992e182e370a6f"
-  dependencies:
-    flow-bin "^0.50.0"
-    uuid "^2.0.1"
 
 js-yaml@^3.10.0, js-yaml@^3.4.3, js-yaml@^3.9.1:
   version "3.10.0"
@@ -8572,14 +8561,6 @@ redux-logger@^3.0.1, redux-logger@^3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
-redux-search@^2.3.3:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/redux-search/-/redux-search-2.4.0.tgz#da21448b2d0c6508324cf4f93f66f6c6170df00d"
-  dependencies:
-    babel-runtime "^6.11.6"
-    js-worker-search "^1.2.0"
-    redux "^3.0.4"
-
 redux-throttle@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/redux-throttle/-/redux-throttle-0.1.1.tgz#43070573f0331d12ae16fae6572ad9d7fcb761ae"
@@ -8599,7 +8580,7 @@ redux@3.6.0:
     loose-envify "^1.1.0"
     symbol-observable "^1.0.2"
 
-redux@^3.0.4, redux@^3.6.0, redux@^3.7.0, redux@^3.7.2:
+redux@^3.6.0, redux@^3.7.0, redux@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
   dependencies:
@@ -10557,7 +10538,7 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^2.0.1, uuid@^2.0.2:
+uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 


### PR DESCRIPTION
For large genes/regions, redux-search takes a long time to build an index. While it's building that index, entering *any* search query results in "No variants found" without any indication that searching won't work correctly yet.

Since the variant fields which are searched are not free form text and we don't order variants by relevance to the search query, we don't need the full text search that redux-search provides. A string match on the field's value will suffice.

By removing the indexing step, this change makes the variant search feature immediately available once a gene/region has loaded.