### PR TITLE
Fix variant track scale when window is resized

### DIFF
--- a/packages/track-variant/src/VariantAlleleFrequencyPlot.js
+++ b/packages/track-variant/src/VariantAlleleFrequencyPlot.js
@@ -67,12 +67,9 @@ export class VariantAlleleFrequencyPlot extends Component {
   }
 
   canvasRef = (el) => {
-    if (el) {
-      this.ctx = el.getContext('2d')
-      this.ctx.scale(CANVAS_SCALE, CANVAS_SCALE)
-    } else {
-      this.ctx = null
-    }
+    this.ctx = el
+      ? el.getContext('2d')
+      : null
   }
 
   draw() {
@@ -86,6 +83,7 @@ export class VariantAlleleFrequencyPlot extends Component {
 
     const markerY = height / 2
 
+    this.ctx.setTransform(CANVAS_SCALE, 0, 0, CANVAS_SCALE, 0, 0)
     this.ctx.clearRect(0, 0, width, height)
     this.ctx.lineWidth = 0.5
     this.ctx.strokeStyle = '#000'


### PR DESCRIPTION
Currently, the variant track gets incorrectly scaled when the window is resized.

## Before
<img width="903" alt="screen shot 2018-07-19 at 10 50 35 am" src="https://user-images.githubusercontent.com/1156625/42950353-cf15e704-8b41-11e8-8d3b-674349a78bfd.png">

## After
<img width="901" alt="screen shot 2018-07-19 at 10 49 26 am" src="https://user-images.githubusercontent.com/1156625/42950352-cf06a33e-8b41-11e8-81a1-93e8e5b72f42.png">
