### PR TITLE
Fix searching variants by consequence

### DIFF
--- a/projects/gnomad/src/Main.js
+++ b/projects/gnomad/src/Main.js
@@ -12,12 +12,39 @@ import toc from './toc.json'
 const sum = (oldValue, newValue) => oldValue + newValue
 const concat = (oldValue, newValue) => oldValue.concat(newValue)
 
+
+const consequenceLabels = {
+  mis: 'missense',
+  missense_variant: 'missense',
+  ns: 'inframe indel',
+  inframe_insertion: 'inframe insertion',
+  inframe_deletion: 'inframe deletion',
+  syn: 'synonymous',
+  synonymous_variant: 'synonymous',
+  upstream_gene_variant: 'upstream gene',
+  downstream_gene_variant: 'downstream gene',
+  intron_variant: 'intron',
+  '3_prime_UTR_variant': "3' UTR",
+  '5_prime_UTR_variant': "5' UTR",
+  splice: 'splice region',
+  splice_region_variant: 'splice region',
+  splice_donor_variant: 'splice donor',
+  splice_acceptor_variant: 'splice acceptor',
+  frameshift_variant: 'frameshift',
+  stop_gained: 'stop gained',
+  stop_lost: 'stop lost',
+  start_lost: 'start lost',
+  lof: 'loss of function',
+}
+
+
 const appSettings = {
   variantSearchPredicate(variant, query) {
+    const consequence = consequenceLabels[variant.get('consequence')] || ''
     return (
       variant.get('variant_id').toLowerCase().includes(query)
       || (variant.get('rsid') || '').toLowerCase().includes(query)
-      || (variant.get('consequence') || '').toLowerCase().includes(query)
+      || consequence.toLowerCase().includes(query)
       || (variant.get('hgvsp') || '').toLowerCase().includes(query)
       || (variant.get('hgvsc') || '').toLowerCase().includes(query)
     )


### PR DESCRIPTION
Quick fix for #45 and #134.

Eventually, these consequence labels should be consolidated somewhere. They're currently duplicated  in the Table component and gnomAD/SCHEMA's main files.