### PR TITLE
Render filtered variants in navigator track

### DIFF
--- a/packages/track-navigator/package.json
+++ b/packages/track-navigator/package.json
@@ -7,17 +7,15 @@
     "lib"
   ],
   "dependencies": {
-    "@broad/utilities": "0.0.1",
-    "d3-array": "^1.2.0",
+    "@broad/redux-variants": "*",
+    "@broad/table": "*",
+    "@broad/utilities": "*",
     "d3-scale": "^1.0.6",
-    "d3-shape": "^1.2.0",
+    "prop-types": "^15.5.10",
     "react-cursor-position": "^2.1.0"
   },
   "peerDependencies": {
-    "@broad/track-region": "*",
-    "prop-types": "^15.5.10",
     "react": "^15.5.4",
-    "ramda": "^0.24.1",
     "styled-components": "^2.1.2"
   }
 }

--- a/packages/track-navigator/src/Navigator.js
+++ b/packages/track-navigator/src/Navigator.js
@@ -145,6 +145,33 @@ const ClickArea = ({
   )
 }
 
+ClickArea.propTypes = {
+  currentTableScrollData: PropTypes.shape({
+    scrollHeight: PropTypes.number.isRequired,
+    scrollTop: PropTypes.number.isRequired,
+  }).isRequired,
+  height: PropTypes.number,
+  hoveredVariant: PropTypes.string.isRequired,
+  invertOffset: PropTypes.func.isRequired,
+  isPositionOutside: PropTypes.bool,
+  onNavigatorClick: PropTypes.func.isRequired,
+  position: PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+  }),
+  positionOffset: PropTypes.func.isRequired,
+  variants: PropTypes.object.isRequired,
+  width: PropTypes.number.isRequired,
+  xScale: PropTypes.func.isRequired,
+}
+
+ClickArea.defaultProps = {
+  height: 60,
+  isPositionOutside: true,
+  position: undefined,
+}
+
+
 const NavigatorTrackContainer = styled.div`
   display: flex;
 `
@@ -173,7 +200,23 @@ const NavigatorTrack = (props) => {
 }
 
 NavigatorTrack.propTypes = {
-  width: PropTypes.number,
+  currentTableScrollData: PropTypes.shape({
+    scrollHeight: PropTypes.number.isRequired,
+    scrollTop: PropTypes.number.isRequired,
+  }).isRequired,
+  hoveredVariant: PropTypes.string.isRequired,
+  invertOffset: PropTypes.func.isRequired,
+  leftPanelWidth: PropTypes.number.isRequired,
+  onNavigatorClick: PropTypes.func.isRequired,
+  positionOffset: PropTypes.func.isRequired,
+  title: PropTypes.string,
+  variants: PropTypes.object.isRequired,
+  width: PropTypes.number.isRequired,
+  xScale: PropTypes.func.isRequired,
+}
+
+NavigatorTrack.defaultProps = {
+  title: '',
 }
 
 export default NavigatorTrack

--- a/packages/track-navigator/src/Navigator.js
+++ b/packages/track-navigator/src/Navigator.js
@@ -1,22 +1,11 @@
-/* eslint-disable space-before-function-paren */
-/* eslint-disable no-shadow */
-/* eslint-disable comma-dangle */
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/extensions */
-/* eslint-disable no-case-declarations */
-/* eslint-disable react/prop-types */
-
-import React from 'react'
-import PropTypes from 'prop-types'
-import styled from 'styled-components'
-import ReactCursorPosition from 'react-cursor-position'
-import R from 'ramda'
-import { getTableIndexByPosition } from '@broad/utilities/src/variant'
-import { range } from 'd3-array'
-import { line } from 'd3-shape'
 import { scaleLog } from 'd3-scale'
+import PropTypes from 'prop-types'
+import React from 'react'
+import ReactCursorPosition from 'react-cursor-position'
+import styled from 'styled-components'
 
 import { getCategoryFromConsequence } from '@broad/utilities/src/constants/categoryDefinitions'
+import { getTableIndexByPosition } from '@broad/utilities/src/variant'
 
 const NavigatorAxisName = styled.div`
   display: flex;
@@ -26,31 +15,6 @@ const NavigatorAxisName = styled.div`
   margin-left: 30;
   width: ${props => props.leftPanelWidth}px;
 `
-
-//
-// const AreaClick = styled.div`
-//   border: 1px solid yellow;
-// `
-//
-// const NavigatorContainerRect = styled.div`
-//   fill: #DAEDE2;
-//   stroke: red;
-// `
-//
-// const CursorPositionRect = styled.div`
-//   fill: #EA2E49;
-//   stroke: black;
-//   stroke-width: 1px;
-//   cursor: pointer;
-// `
-//
-// const TablePositionRect = styled.div`
-//   fill: green;
-//   stroke: black;
-//   stroke-width: 1px;
-// `
-//
-
 
 const NavigatorAxis = ({ title, height, leftPanelWidth }) => {
   return (
@@ -71,18 +35,13 @@ const ClickArea = ({
   xScale,
   position, // active mouse position from ReactCursorPosition
   isPositionOutside, // from ReactCursorPosition
-  // scrollSync, // position in from table
   currentTableScrollData,
   onNavigatorClick,
-  variantPlotData, // TODO
   variants,
   hoveredVariant,
-  variantSortKey, // TODO
-  noVariants,
 }) => {
-
   if (variants.size === 0) {
-    return <p></p>
+    return <div />
   }
   const numberOfVariantsVisibleInTable = 20
   const { scrollHeight, scrollTop } = currentTableScrollData
@@ -91,25 +50,14 @@ const ClickArea = ({
 
   if (variants.size < scrollSync + numberOfVariantsVisibleInTable) {
     currentlyVisibleVariants = variants.slice(0, numberOfVariantsVisibleInTable).toJS()
-    // .filter(v => !isNaN(xScale(positionOffset(v.pos).offsetPosition)))
   } else {
     currentlyVisibleVariants = variants.slice(
       scrollSync, scrollSync + numberOfVariantsVisibleInTable
     ).toJS()
-    // .filter(v => !isNaN(xScale(positionOffset(v.pos).offsetPosition)))
   }
   if (currentlyVisibleVariants.length === 0) {
-    return <p></p>
+    return <div />
   }
-  const tablePositionStart = R.head(currentlyVisibleVariants).pos
-  const tablePositionStop = R.last(currentlyVisibleVariants).pos
-
-  const tableRectPadding = 10
-  const tableRectStart = xScale(
-    positionOffset(tablePositionStart).offsetPosition
-  ) - tableRectPadding
-  const tableRectStop = xScale(positionOffset(tablePositionStop).offsetPosition)
-  const tableRectWidth = tableRectStop - (tableRectStart + tableRectPadding) // TODO
 
   const variantPositions = currentlyVisibleVariants.map(v => ({
     x: xScale(positionOffset(v.pos).offsetPosition),
@@ -163,28 +111,6 @@ const ClickArea = ({
       </g>
     )
   })
-
-
-  // let allVariantMarks
-  // if (variants.size < 300) {
-  //   const allVariantPositions = variants.map((v) => {
-  //     return ({
-  //       x: xScale(positionOffset(v.pos).offsetPosition),
-  //       variant_id: v.variant_id,
-  //       allele_freq: v.allele_freq,
-  //     })
-  //   }).filter(v => !isNaN(v.x))
-  //   allVariantMarks = allVariantPositions.map((v, i) => (
-  //     <g key={`variant-${v}-${i}`}>
-  //       <circle
-  //         cx={v.x}
-  //         cy={height / 2.5}
-  //         r={afScale(v.allele_freq)}
-  //         fill={'grey'}
-  //       />
-  //     </g>
-  //   ))
-  // }
 
   const PositionMarks = () => {
     const tickHeight = 3
@@ -286,15 +212,6 @@ const ClickArea = ({
         height={height}
         fill={'none'}
       />
-    {/*!noVariants && variantSortKey === 'pos' &&
-      <rect
-        className={'tablePositionRect'}
-        x={tableRectStart}
-        y={0 + navigatorBoxTopPadding}
-        width={tableRectWidth}
-        height={height - navigatorBoxBottomPadding}
-        strokeDasharray={'5, 5'}
-      />*/}
 
       {!isPositionOutside &&
       <rect
@@ -311,8 +228,7 @@ const ClickArea = ({
           cursor: 'pointer',
         }}
       />}
-      {/* {!noVariants && variants.size < 300 && allVariantMarks} */}
-      {!noVariants && variantMarks}
+      {variantMarks}
       <PositionMarks />
     </svg>
   )
@@ -321,7 +237,6 @@ const ClickArea = ({
 const NavigatorTrackContainer = styled.div`
   display: flex;
   align-items: center;
-  ${'' /* border: 1px solid blue; */}
 `
 
 const NavigatorTrack = (props) => {
@@ -340,7 +255,7 @@ const NavigatorTrack = (props) => {
 }
 NavigatorTrack.propTypes = {
   height: PropTypes.number,
-  width: PropTypes.number,  // eslint-disable-line
+  width: PropTypes.number,
 }
 NavigatorTrack.defaultProps = {
   height: 60,

--- a/packages/track-navigator/src/Navigator.js
+++ b/packages/track-navigator/src/Navigator.js
@@ -7,6 +7,8 @@ import styled from 'styled-components'
 import { getCategoryFromConsequence } from '@broad/utilities/src/constants/categoryDefinitions'
 import { getTableIndexByPosition } from '@broad/utilities/src/variant'
 
+import PositionAxis from './PositionAxis'
+
 
 const ClickArea = ({
   height,
@@ -71,7 +73,7 @@ const ClickArea = ({
       <g key={`variant-${v}-${i}`}>
         {v.variant_id === hoveredVariant && <ellipse
           cx={v.x}
-          cy={height / 2.5}
+          cy={height / 2}
           ry={afScale(v.allele_freq) + 4}
           rx={10}
           fill={'rgba(0,0,0,0)'}
@@ -81,7 +83,7 @@ const ClickArea = ({
         />}
         <ellipse
           cx={v.x}
-          cy={height / 2.5}
+          cy={height / 2}
           ry={afScale(v.allele_freq)}
           rx={3}
           fill={localColor}
@@ -93,125 +95,53 @@ const ClickArea = ({
     )
   })
 
-  const PositionMarks = () => {
-    const tickHeight = 3
-    const numberOfTicks = 10
-    const textRotationDegrees = 0
-    const textXOffsetFromTick = 0
-    const textYOffsetFromTick = 7
-    const tickPositions = range(0, width, width / numberOfTicks)
-    const tickGenomePositions = tickPositions.map(t => ({ x: t, label: invertOffset(t) }))
-
-    const tickDrawing = (x, genomePositionLabel) => (
-      <g key={`tick-${x}-axis`}>
-        <line
-          className={'xTickLine'}
-          x1={x}
-          x2={x}
-          y1={height - 2}
-          y2={height - 2 - tickHeight}
-          stroke={'black'}
-          strokeWidth={1}
-        />
-        <text
-          style={{ textAnchor: 'center', fontSize: '10px' }}
-          x={x + textXOffsetFromTick}
-          y={height - textYOffsetFromTick}
-          transform={`rotate(${360 - textRotationDegrees} ${x} ${height})`}
-        >
-          {genomePositionLabel}
-        </text>
-      </g>
-    )
-
-    const axisTicksDrawing = R.tail(tickGenomePositions.map(
-      ({ x, label }) => tickDrawing(x, label))
-    )
-
-    return (
-      <g>
-        <line
-          className={'xAxisLine'}
-          x1={0 + 2}
-          x2={width - 2}
-          y1={height - 1}
-          y2={height - 1}
-          stroke={'black'}
-          strokeWidth={1}
-        />
-        <line
-          className={'yAxisLine'}
-          x1={1}
-          x2={1}
-          y1={height - 7}
-          y2={height}
-          stroke={'black'}
-          strokeWidth={1}
-        />
-        <line
-          className={'yAxisLine'}
-          x1={width - 1}
-          x2={width - 1}
-          y1={height - 7}
-          y2={height}
-          stroke={'black'}
-          strokeWidth={1}
-        />
-        {axisTicksDrawing}
-      </g>
-    )
-  }
-
-  const navigatorBoxBottomPadding = 20
-  const navigatorBoxTopPadding = 4
-
   return (
-    <svg
-      className={'areaClick'}
-      width={width}
-      height={height}
-      onClick={(_) => {
+    <div
+      onClick={() => {
         const genomePos = invertOffset(position.x)
         const tableIndex = getTableIndexByPosition(genomePos, variants.toJS())
         onNavigatorClick(tableIndex, genomePos)
       }}
-      onTouchStart={(_) => {
+      onTouchStart={() => {
         const genomePos = invertOffset(position.x)
         const tableIndex = getTableIndexByPosition(genomePos, variants.toJS())
         onNavigatorClick(tableIndex, genomePos)
       }}
-      style={{
-        cursor: 'pointer',
-      }}
-
+      style={{ cursor: 'pointer', width: `${width}px` }}
     >
-      <rect
-        className={'navigatorContainerRect'}
-        x={0}
-        y={0}
-        width={width}
-        height={height}
-        fill={'none'}
-      />
+      <svg height={height} width={width}>
+        <rect
+          className={'navigatorContainerRect'}
+          x={0}
+          y={0}
+          width={width}
+          height={height}
+          fill={'none'}
+        />
 
-      {!isPositionOutside &&
-      <rect
-        className={'cursorPositionRect'}
-        x={position.x - 15}
-        y={0 + navigatorBoxTopPadding}
-        width={30}
-        height={height - navigatorBoxBottomPadding}
-        strokeDasharray={'5, 5'}
-        fill={'none'}
-        stroke={'black'}
-        strokeWidth={'1px'}
-        style={{
-          cursor: 'pointer',
-        }}
-      />}
-      {variantMarks}
-      <PositionMarks />
-    </svg>
+        {!isPositionOutside &&
+        <rect
+          className={'cursorPositionRect'}
+          x={position.x - 15}
+          y={0}
+          width={30}
+          height={height}
+          strokeDasharray={'5, 5'}
+          fill={'none'}
+          stroke={'black'}
+          strokeWidth={'1px'}
+          style={{
+            cursor: 'pointer',
+          }}
+        />}
+        {variantMarks}
+      </svg>
+      <PositionAxis
+        height={height}
+        invertOffset={invertOffset}
+        width={width}
+      />
+    </div>
   )
 }
 

--- a/packages/track-navigator/src/Navigator.js
+++ b/packages/track-navigator/src/Navigator.js
@@ -7,25 +7,6 @@ import styled from 'styled-components'
 import { getCategoryFromConsequence } from '@broad/utilities/src/constants/categoryDefinitions'
 import { getTableIndexByPosition } from '@broad/utilities/src/variant'
 
-const NavigatorAxisName = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  font-size: 12px;
-  margin-left: 30;
-  width: ${props => props.leftPanelWidth}px;
-`
-
-const NavigatorAxis = ({ title, height, leftPanelWidth }) => {
-  return (
-    <NavigatorAxisName leftPanelWidth={leftPanelWidth} height={height}>
-      {title}
-    </NavigatorAxisName>
-  )
-}
-NavigatorAxis.propTypes = {
-  leftPanelWidth: PropTypes.number.isRequired,
-}
 
 const ClickArea = ({
   height,
@@ -236,29 +217,33 @@ const ClickArea = ({
 
 const NavigatorTrackContainer = styled.div`
   display: flex;
-  align-items: center;
 `
+
+
+const LeftPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 60px;
+  justify-content: center;
+  width: ${props => props.width}px;
+`
+
 
 const NavigatorTrack = (props) => {
   return (
     <NavigatorTrackContainer>
-      <NavigatorAxis
-        title={props.title}
-        height={props.height}
-        leftPanelWidth={props.leftPanelWidth}
-      />
+      <LeftPanel width={props.leftPanelWidth}>
+        {props.title}
+      </LeftPanel>
       <ReactCursorPosition className={'cursorPosition'}>
         <ClickArea {...props} />
       </ReactCursorPosition>
     </NavigatorTrackContainer>
   )
 }
+
 NavigatorTrack.propTypes = {
-  height: PropTypes.number,
   width: PropTypes.number,
-}
-NavigatorTrack.defaultProps = {
-  height: 60,
 }
 
 export default NavigatorTrack

--- a/packages/track-navigator/src/Navigator.js
+++ b/packages/track-navigator/src/Navigator.js
@@ -18,26 +18,19 @@ const ClickArea = ({
   xScale,
   position, // active mouse position from ReactCursorPosition
   isPositionOutside, // from ReactCursorPosition
-  currentTableScrollData,
   onNavigatorClick,
   variants,
+  visibleVariantWindow,
   hoveredVariant,
 }) => {
   if (variants.size === 0) {
     return <div />
   }
-  const numberOfVariantsVisibleInTable = 20
-  const { scrollHeight, scrollTop } = currentTableScrollData
-  const scrollSync = Math.floor((scrollTop / scrollHeight) * variants.size)
-  let currentlyVisibleVariants
 
-  if (variants.size < scrollSync + numberOfVariantsVisibleInTable) {
-    currentlyVisibleVariants = variants.slice(0, numberOfVariantsVisibleInTable).toJS()
-  } else {
-    currentlyVisibleVariants = variants.slice(
-      scrollSync, scrollSync + numberOfVariantsVisibleInTable
-    ).toJS()
-  }
+  const currentlyVisibleVariants = variants
+    .slice(visibleVariantWindow[0], visibleVariantWindow[1])
+    .toJS()
+
   if (currentlyVisibleVariants.length === 0) {
     return <div />
   }
@@ -146,10 +139,6 @@ const ClickArea = ({
 }
 
 ClickArea.propTypes = {
-  currentTableScrollData: PropTypes.shape({
-    scrollHeight: PropTypes.number.isRequired,
-    scrollTop: PropTypes.number.isRequired,
-  }).isRequired,
   height: PropTypes.number,
   hoveredVariant: PropTypes.string.isRequired,
   invertOffset: PropTypes.func.isRequired,
@@ -161,6 +150,7 @@ ClickArea.propTypes = {
   }),
   positionOffset: PropTypes.func.isRequired,
   variants: PropTypes.object.isRequired,
+  visibleVariantWindow: PropTypes.arrayOf(PropTypes.number).isRequired,
   width: PropTypes.number.isRequired,
   xScale: PropTypes.func.isRequired,
 }
@@ -200,10 +190,6 @@ const NavigatorTrack = (props) => {
 }
 
 NavigatorTrack.propTypes = {
-  currentTableScrollData: PropTypes.shape({
-    scrollHeight: PropTypes.number.isRequired,
-    scrollTop: PropTypes.number.isRequired,
-  }).isRequired,
   hoveredVariant: PropTypes.string.isRequired,
   invertOffset: PropTypes.func.isRequired,
   leftPanelWidth: PropTypes.number.isRequired,
@@ -211,6 +197,7 @@ NavigatorTrack.propTypes = {
   positionOffset: PropTypes.func.isRequired,
   title: PropTypes.string,
   variants: PropTypes.object.isRequired,
+  visibleVariantWindow: PropTypes.arrayOf(PropTypes.number).isRequired,
   width: PropTypes.number.isRequired,
   xScale: PropTypes.func.isRequired,
 }

--- a/packages/track-navigator/src/Navigator.js
+++ b/packages/track-navigator/src/Navigator.js
@@ -99,9 +99,9 @@ class Navigator extends Component {
       return null
     }
 
-    if (variant.allele_freq === 0) {
-      return null
-    }
+    const ry = (variant.allele_freq === 0)
+      ? 4
+      : afScale(variant.allele_freq) + 4
 
     const x = xScale(positionOffset(variant.pos).offsetPosition)
 
@@ -110,7 +110,7 @@ class Navigator extends Component {
         cx={x}
         cy={height / 2}
         rx={10}
-        ry={afScale(variant.allele_freq) + 4}
+        ry={ry}
         fill="none"
         stroke="black"
         strokeDasharray="3, 3"
@@ -126,8 +126,20 @@ class Navigator extends Component {
       xScale,
     } = this.props
 
-    return visibleVariants.filter(v => v.allele_freq !== 0).map((variant) => {
-      const color = exacClassicColors[getCategoryFromConsequence(variant.consequence)]
+    return visibleVariants.map((variant) => {
+      let fill
+      let rx
+      let ry
+      if (variant.allele_freq === 0) {
+        fill = 'white'
+        rx = 1
+        ry = 1
+      } else {
+        fill = exacClassicColors[getCategoryFromConsequence(variant.consequence)]
+        rx = 3
+        ry = afScale(variant.allele_freq)
+      }
+
       const x = xScale(positionOffset(variant.pos).offsetPosition)
 
       return (
@@ -135,9 +147,9 @@ class Navigator extends Component {
           key={variant.variant_id}
           cx={x}
           cy={height / 2}
-          rx={3}
-          ry={afScale(variant.allele_freq)}
-          fill={color}
+          rx={rx}
+          ry={ry}
+          fill={fill}
           opacity={0.7}
           stroke="black"
           strokeWidth={0.5}

--- a/packages/track-navigator/src/NavigatorConnected.js
+++ b/packages/track-navigator/src/NavigatorConnected.js
@@ -4,7 +4,6 @@ import {
   finalFilteredVariants,
   hoveredVariant,
   types as variantActionTypes,
-  variantSortKey,
 } from '@broad/redux-variants'
 import {
   actions as tableActions,
@@ -20,7 +19,6 @@ const mapStateToProps = state => ({
   hoveredVariant: hoveredVariant(state),
   scrollSync: currentTableIndex(state),
   variants: finalFilteredVariants(state),
-  variantSortKey: variantSortKey(state),
 })
 
 

--- a/packages/track-navigator/src/NavigatorConnected.js
+++ b/packages/track-navigator/src/NavigatorConnected.js
@@ -7,19 +7,26 @@ import {
 } from '@broad/redux-variants'
 import {
   actions as tableActions,
-  currentTableIndex,
   currentTableScrollData,
 } from '@broad/table'
 
 import NavigatorTrack from './Navigator'
 
 
-const mapStateToProps = state => ({
-  currentTableScrollData: currentTableScrollData(state),
-  hoveredVariant: hoveredVariant(state),
-  scrollSync: currentTableIndex(state),
-  variants: finalFilteredVariants(state),
-})
+const mapStateToProps = (state) => {
+  const variants = finalFilteredVariants(state)
+
+  const { scrollHeight, scrollTop } = currentTableScrollData(state)
+  const tableIndex = Math.floor((scrollTop / scrollHeight) * variants.size)
+  const visibleVariantWindow = [tableIndex, tableIndex + 20]
+
+  return {
+    currentTableScrollData: currentTableScrollData(state),
+    hoveredVariant: hoveredVariant(state),
+    variants: finalFilteredVariants(state),
+    visibleVariantWindow,
+  }
+}
 
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/track-navigator/src/PositionAxis.js
+++ b/packages/track-navigator/src/PositionAxis.js
@@ -1,0 +1,72 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+
+const PositionAxis = ({
+  invertOffset,
+  width,
+}) => {
+  const height = 15
+  const numIntervals = 10
+
+  const tickInterval = width / numIntervals
+  const tickPositions = [...Array(numIntervals - 1)].map((_, i) => tickInterval * (i + 1))
+
+  const ticks = tickPositions.map(x => (
+    <g key={`tick-${x}-axis`}>
+      <line
+        x1={x}
+        y1={height}
+        x2={x}
+        y2={height - 5}
+        stroke="black"
+        strokeWidth={1}
+      />
+      <text
+        x={x}
+        y={height - 7}
+        textAnchor="center"
+        style={{ fontSize: '10px' }}
+      >
+        {invertOffset(x)}
+      </text>
+    </g>
+  ))
+
+  return (
+    <svg height={height} width={width}>
+      <line
+        x1={0}
+        y1={height}
+        x2={width}
+        y2={height}
+        stroke="black"
+        strokeWidth={2}
+      />
+      <line
+        x1={0}
+        y1={height - 7}
+        x2={0}
+        y2={height}
+        stroke="black"
+        strokeWidth={2}
+      />
+      <line
+        x1={width}
+        y1={height - 7}
+        x2={width}
+        y2={height}
+        stroke="black"
+        strokeWidth={2}
+      />
+      {ticks}
+    </svg>
+  )
+}
+
+PositionAxis.propTypes = {
+  invertOffset: PropTypes.func.isRequired,
+  width: PropTypes.number.isRequired,
+}
+
+export default PositionAxis


### PR DESCRIPTION
Currently, variants with an allele frequency of 0 do not appear in the "Viewing in table" track, even though they do appear in the table.

Resolves #51.