### PR TITLE
Remove deprecated PropTypes imports

### DIFF
--- a/packages/help/src/Help.js
+++ b/packages/help/src/Help.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable template-curly-spacing */
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
 import debounce from 'lodash.debounce'

--- a/packages/plot-traffic/src/example/index.js
+++ b/packages/plot-traffic/src/example/index.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { TrafficBar } from '../index'
 
 const PlotTrafficExample = () => {

--- a/packages/structure-viewer/package.json
+++ b/packages/structure-viewer/package.json
@@ -15,6 +15,7 @@
     "bio-pv": "^1.8.1",
     "immutable": "^3.8.1",
     "keymirror": "^0.1.1",
+    "prop-types": "^15.5.10",
     "ramda": "^0.24.1",
     "react": "^15.6.1",
     "react-redux": "^5.0.5",

--- a/packages/structure-viewer/src/component.js
+++ b/packages/structure-viewer/src/component.js
@@ -2,7 +2,8 @@
 /* eslint-disable space-before-function-paren */
 /* eslint-disable react/prop-types */
 
-import React, { PropTypes, Component } from 'react'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
 import styled from 'styled-components'
 import pv from 'bio-pv'
 

--- a/packages/structure-viewer/src/example/StructureViewerConnected.js
+++ b/packages/structure-viewer/src/example/StructureViewerConnected.js
@@ -1,6 +1,6 @@
 /* eslint-disable arrow-parens */
 /* eslint-disable no-shadow */
-import React, { PropTypes } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
 
 import * as reduxFunctions from '@broad/structure-viewer/src/redux'

--- a/packages/structure-viewer/src/example/index.js
+++ b/packages/structure-viewer/src/example/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable arrow-parens */
 /* eslint-disable no-shadow */
 
-import React, { PropTypes } from 'react'
+import React from 'react'
 import Immutable from 'immutable'
 import { Provider, connect } from 'react-redux'
 

--- a/packages/track-sashimi/src/index.js
+++ b/packages/track-sashimi/src/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-shadow */
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import R from 'ramda'
 
 import { area, line, curveCatmullRom } from 'd3-shape'

--- a/projects/gnomad/src/Settings.js
+++ b/projects/gnomad/src/Settings.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import { connect } from 'react-redux'
 
 import { QuestionMark } from '@broad/help'

--- a/projects/variantfx/src/GenePage/FetchHoc.js
+++ b/projects/variantfx/src/GenePage/FetchHoc.js
@@ -3,7 +3,8 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable import/extensions */
 
-import React, { PropTypes, Component } from 'react'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
 import { actions as variantActions } from '@broad/redux-variants'

--- a/projects/variantfx/src/GenePage/GeneSettings.js
+++ b/projects/variantfx/src/GenePage/GeneSettings.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
 


### PR DESCRIPTION
Importing PropTypes from the react package is deprecated. They should be imported from prop-types instead.