### PR TITLE
Handle variants missing consequence or AF values

### DIFF
--- a/packages/track-variant/src/VariantAlleleFrequencyPlot.js
+++ b/packages/track-variant/src/VariantAlleleFrequencyPlot.js
@@ -48,7 +48,7 @@ export class VariantAlleleFrequencyPlot extends Component {
     positionOffset: PropTypes.func.isRequired,
     variants: PropTypes.arrayOf(
       PropTypes.shape({
-        allele_freq: PropTypes.number.isRequired,
+        allele_freq: PropTypes.number,
         consequence: PropTypes.string,
         pos: PropTypes.number.isRequired,
         variant_id: PropTypes.string.isRequired,
@@ -95,12 +95,13 @@ export class VariantAlleleFrequencyPlot extends Component {
       let rx
       let ry
 
-      if (variant.allele_freq === 0) {
+      if (!variant.allele_freq) {
         fill = 'white'
         rx = 1
         ry = 1
       } else {
-        fill = exacClassicColors[getCategoryFromConsequence(variant.consequence)]
+        const category = getCategoryFromConsequence(variant.consequence) || 'all'
+        fill = exacClassicColors[category]
         rx = 3
         ry = alleleFrequencyScale(variant.allele_freq)
       }

--- a/packages/track-variant/src/VariantAlleleFrequencyTrack.js
+++ b/packages/track-variant/src/VariantAlleleFrequencyTrack.js
@@ -38,8 +38,8 @@ VariantAlleleFrequencyTrack.propTypes = {
   title: PropTypes.string,
   variants: PropTypes.arrayOf(
     PropTypes.shape({
-      allele_freq: PropTypes.number.isRequired,
-      consequence: PropTypes.string.isRequired,
+      allele_freq: PropTypes.number,
+      consequence: PropTypes.string,
       pos: PropTypes.number.isRequired,
       variant_id: PropTypes.string.isRequired,
     })


### PR DESCRIPTION
Some variants have null values for consequence and/or allele frequency.

Null values for allele frequency result in the variant track attempting to draw an ellipse with a y radius of -Infinity.

Null values for consequence result in variant markers with an undefined fill color. These should be given the default fill color for all variants that are not in LoF/missense/synonymous categories.