### PR TITLE
Remove unused footer component from gene page

### DIFF
--- a/projects/gnomad/src/GenePage/index.js
+++ b/projects/gnomad/src/GenePage/index.js
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 import { GenePageHoc } from '@broad/redux-genes'
 import { actions as variantActions } from '@broad/redux-variants'
 import { VariantTable } from '@broad/table'
-
 import {
   GenePage,
   Summary,
@@ -13,36 +12,13 @@ import {
   ClassicExacButton,
 } from '@broad/ui'
 
-import { HelpLink } from '@broad/help'
-
+import { exportFetch } from './exportFetch'
+import { fetchGnomadGenePage } from './fetch'
 import GeneInfo from './GeneInfo'
 import Settings from '../Settings'
 import GeneViewer from './RegionViewer'
-
 import tableConfig from '../tableConfig'
-import { fetchGnomadGenePage } from './fetch'
-import { exportFetch } from './exportFetch'
 
-const Footer = styled.div`
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 5px;
-`
-
-const FooterItem = styled.div`
-  & > a {
-    text-decoration: none;
-    color: #428bca;
-    &:hover  {
-      color: #BE4248;
-    }
-  }
-  font-size: 16px;
-  margin-right: 10px;
-`
 
 const BottomButtonSection = styled.div`
   width: 100%;
@@ -75,14 +51,6 @@ const GenePageConnected = () => {
           </ExportVariantsButton>
         </BottomButtonSection>
       </TableSection>
-      {/* <Footer>
-        <FooterItem>
-          <HelpLink topic={'about-gnomad'}>About</HelpLink>
-        </FooterItem>
-        <FooterItem>
-          <HelpLink topic={'terms'}>Terms</HelpLink>
-        </FooterItem>
-      </Footer> */}
     </GenePage>
   )
 }


### PR DESCRIPTION
If there is to be a footer, it should be in routes.js instead of the gene page. But the links in this unused footer are already present in the top bar.