### PR TITLE
Move component definitions out of GenesTrack render

### DIFF
--- a/packages/track-genes/src/GenesTrack.js
+++ b/packages/track-genes/src/GenesTrack.js
@@ -1,8 +1,43 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 import styled from 'styled-components'
 
 import { formatGenes, createTracks } from './index'
+
+
+const GeneTrackWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+`
+
+
+const GeneTrackLeft = styled.div`
+  height: 100%;
+  width: ${props => props.width}px;
+`
+
+
+const GeneTrackData = styled.div`
+  height: 100%;
+`
+
+
+const GeneTrackTitle = styled.div``
+
+
+const GeneTrackTitleText = styled.div`
+  margin: 0 0 0 0;
+  padding: 0 0 0 0;
+`
+
+const GeneGroup = styled.g`
+  &:hover {
+    fill: red;
+    cursor: pointer;
+  }
+`
 
 const GenesTrack = ({
   genes,
@@ -12,44 +47,11 @@ const GenesTrack = ({
   onGeneClick,
 }) => {
   const GENE_TRACK_HEIGHT = 50
-  const GENE_TRACK_PADDING = 3
-
-  const GeneTrackWrapper = styled.div`
-    display: flex;
-    flex-direction: row;
-    width: 100%;
-    height: 100%;
-  `
-
-  const GeneTrackLeft = styled.div`
-    height: 100%;
-    width: ${leftPanelWidth}px;
-  `
-
-  const GeneTrackData = styled.div`
-    height: 100%;
-  `
-
-  const GeneTrackTitle = styled.div`
-    height: ${GENE_TRACK_HEIGHT + 3}px;
-  `
-  const GeneTrackTitleText = styled.div`
-    margin: 0 0 0 0;
-    padding: 0 0 0 0;
-  `
-
-  const GeneGroup = styled.g`
-    &:hover {
-      fill: red;
-      cursor: pointer;
-    }
-  `
-
   const tracksToMap = createTracks(formatGenes(genes), xScale).toJS()
 
   return (
     <GeneTrackWrapper>
-      <GeneTrackLeft>
+      <GeneTrackLeft width={leftPanelWidth}>
         <GeneTrackTitle>
           <GeneTrackTitleText>Genes</GeneTrackTitleText>
         </GeneTrackTitle>

--- a/packages/track-genes/src/example/index.js
+++ b/packages/track-genes/src/example/index.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
-import RegionViewer from '@broad/region'
 
-import  GenesTrack  from '../GenesTrack'
+import { RegionViewer } from '@broad/region'
 
-import regionData from '@resources/2-175000717-180995530.json'  // eslint-disable-line
+import regionData from '@resources/2-175000717-180995530.json'
+
+import { GenesTrack } from '..'
+
 
 const Wrapper = styled.div`
   padding-left: 50px;
@@ -25,7 +27,8 @@ const featuresToDisplay = ['default']
 const { genes } = regionData
 console.log(genes)
 
-export default () => {
+
+const GenesTrackExample = () => {
   return (
     <Wrapper>
       <RegionViewer
@@ -34,9 +37,13 @@ export default () => {
         regions={regions}
         featuresToDisplay={featuresToDisplay}
       >
-        <GenesTrack genes={genes}/>
+        <GenesTrack
+          genes={genes}
+          onGeneClick={console.log}
+        />
       </RegionViewer>
     </Wrapper>
   )
 }
 
+export default GenesTrackExample


### PR DESCRIPTION
Defining components inside render prevents React from reconciling the component tree.