### PR TITLE
Reuse variant track's plot in navigator track

### DIFF
--- a/packages/track-navigator/package.json
+++ b/packages/track-navigator/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@broad/redux-variants": "*",
     "@broad/table": "*",
+    "@broad/track-variant": "*",
     "@broad/utilities": "*",
     "d3-scale": "^1.0.6",
     "prop-types": "^15.5.10",

--- a/packages/track-navigator/src/Navigator.js
+++ b/packages/track-navigator/src/Navigator.js
@@ -15,6 +15,20 @@ const afScale = scaleLog()
   .range([4, 12])
 
 
+const NavigatorContainer = styled.div`
+  cursor: pointer;
+  position: relative;
+  width: ${props => props.width}px;
+`
+
+
+const NavigatorOverlay = styled.svg`
+  left: 0;
+  position: absolute;
+  top: 0;
+`
+
+
 class Navigator extends Component {
   static propTypes = {
     height: PropTypes.number,
@@ -152,21 +166,21 @@ class Navigator extends Component {
     }
 
     return (
-      <div
+      <NavigatorContainer
         onClick={this.onClick}
         onTouchStart={this.onClick}
-        style={{ cursor: 'pointer', position: 'relative', width: `${width}px` }}
+        width={width}
       >
         {this.renderVisibleVariants(visibleVariants)}
-        <svg height={height} width={width} style={{ position: 'absolute', top: 0, left: 0 }}>
+        <NavigatorOverlay height={height} width={width}>
           {this.renderHoveredVariant(visibleVariants)}
           {this.renderCursor()}
-        </svg>
+        </NavigatorOverlay>
         <PositionAxis
           invertOffset={invertOffset}
           width={width}
         />
-      </div>
+      </NavigatorContainer>
     )
   }
 }

--- a/packages/track-navigator/src/Navigator.js
+++ b/packages/track-navigator/src/Navigator.js
@@ -91,9 +91,9 @@ class Navigator extends Component {
       return null
     }
 
-    const ry = (variant.allele_freq === 0)
-      ? 4
-      : afScale(variant.allele_freq) + 4
+    const ry = variant.allele_freq
+      ? afScale(variant.allele_freq) + 4
+      : 4
 
     const x = xScale(positionOffset(variant.pos).offsetPosition)
 

--- a/packages/track-navigator/src/Navigator.js
+++ b/packages/track-navigator/src/Navigator.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react'
 import ReactCursorPosition from 'react-cursor-position'
 import styled from 'styled-components'
 
-import { getCategoryFromConsequence } from '@broad/utilities/src/constants/categoryDefinitions'
+import { VariantAlleleFrequencyPlot } from '@broad/track-variant'
 import { getTableIndexByPosition } from '@broad/utilities/src/variant'
 
 import PositionAxis from './PositionAxis'
@@ -13,14 +13,6 @@ import PositionAxis from './PositionAxis'
 const afScale = scaleLog()
   .domain([0.000010, 0.001])
   .range([4, 12])
-
-
-const exacClassicColors = {
-  all: '#757575',
-  missense: '#F0C94D',
-  lof: '#FF583F',
-  synonymous: 'green',
-}
 
 
 class Navigator extends Component {
@@ -123,39 +115,19 @@ class Navigator extends Component {
     const {
       height,
       positionOffset,
+      width,
       xScale,
     } = this.props
 
-    return visibleVariants.map((variant) => {
-      let fill
-      let rx
-      let ry
-      if (variant.allele_freq === 0) {
-        fill = 'white'
-        rx = 1
-        ry = 1
-      } else {
-        fill = exacClassicColors[getCategoryFromConsequence(variant.consequence)]
-        rx = 3
-        ry = afScale(variant.allele_freq)
-      }
-
-      const x = xScale(positionOffset(variant.pos).offsetPosition)
-
-      return (
-        <ellipse
-          key={variant.variant_id}
-          cx={x}
-          cy={height / 2}
-          rx={rx}
-          ry={ry}
-          fill={fill}
-          opacity={0.7}
-          stroke="black"
-          strokeWidth={0.5}
-        />
-      )
-    })
+    return (
+      <VariantAlleleFrequencyPlot
+        height={height}
+        positionOffset={positionOffset}
+        variants={visibleVariants}
+        width={width}
+        xScale={xScale}
+      />
+    )
   }
 
   render() {
@@ -183,10 +155,10 @@ class Navigator extends Component {
       <div
         onClick={this.onClick}
         onTouchStart={this.onClick}
-        style={{ cursor: 'pointer', width: `${width}px` }}
+        style={{ cursor: 'pointer', position: 'relative', width: `${width}px` }}
       >
-        <svg height={height} width={width}>
-          {this.renderVisibleVariants(visibleVariants)}
+        {this.renderVisibleVariants(visibleVariants)}
+        <svg height={height} width={width} style={{ position: 'absolute', top: 0, left: 0 }}>
           {this.renderHoveredVariant(visibleVariants)}
           {this.renderCursor()}
         </svg>

--- a/packages/track-variant/src/index.js
+++ b/packages/track-variant/src/index.js
@@ -1,2 +1,3 @@
+export { VariantAlleleFrequencyPlot } from './VariantAlleleFrequencyPlot'
 export { VariantAlleleFrequencyTrack } from './VariantAlleleFrequencyTrack'
 export { VariantPositionTrack } from './VariantPositionTrack'


### PR DESCRIPTION
Follow on to #136 and #139. Reuse the plot component from the variant track in the navigator track to ensure that they are rendered consistently.