### PR TITLE
Remove extra calculation of default consequence filter

### DIFF
--- a/packages/redux-variants/variants.js
+++ b/packages/redux-variants/variants.js
@@ -255,19 +255,7 @@ export default function createVariantReducer({
     },
 
     [geneTypes.RECEIVE_GENE_DATA] (state, { geneData }) {
-      const exons = geneData.getIn(['transcript', 'exons']).toJS()
-      const padding = 75
-      const totalBasePairs = exons.filter(region => region.feature_type === 'CDS')
-        .reduce((acc, { start, stop }) => (acc + ((stop - start) + (padding * 2))), 0)
-
-      let defaultFilter = 'all'
-      if (totalBasePairs > 40000) {
-        defaultFilter = 'lof'
-      } else if (totalBasePairs > 15000) {
-        defaultFilter = 'missenseOrLoF'
-      }
-
-      const withVariants = datasetKeys.reduce((nextState, datasetKey) => {
+      return datasetKeys.reduce((nextState, datasetKey) => {
         let variantMap = {}
         if (geneData.get(datasetKey) && variantDatasets[datasetKey]) {
           geneData.get(datasetKey).forEach((variant) => {
@@ -294,8 +282,6 @@ export default function createVariantReducer({
             .set(datasetKey, OrderedMap(variantMap))
           )
       }, state)
-
-      return withVariants.set('variantFilter', defaultFilter)
     },
 
     [regionTypes.RECEIVE_REGION_DATA] (state, { regionData }) {


### PR DESCRIPTION
This default consequence filter calculated in the variants reducer is immediately overridden by the one calculated by the GenePageContainer component.

https://github.com/macarthur-lab/gnomadjs/blob/a252d6f12d52caf0d6a53d7061e89869347a077d/packages/redux-genes/src/GenePageHoc.js#L127-L141