### PR TITLE
Remove coverage fields from gene in API schema

### DIFF
--- a/packages/api/src/schema/types/coverage.js
+++ b/packages/api/src/schema/types/coverage.js
@@ -48,9 +48,6 @@ const elasticFields = [
 
 export default coverageType
 
-export const lookupCoverageByStartStop = (db, collection, xstart, xstop) =>
-  db.collection(collection).find({ xpos: { '$gte': Number(xstart), '$lte': Number(xstop) } }).toArray()
-
 export const lookupCoverageByIntervals = ({ elasticClient, index, intervals, chrom, obj }) => {
   const timeStart = new Date().getTime() // NOTE: timer
   const padding = 75
@@ -297,9 +294,4 @@ export const lookupCoverageByIntervalsWithBuckets = ({
       resolve([])
     })
   })
-}
-
-export const lookUpCoverageByExonsWithBuckets = ({ elasticClient, index, exons, chrom }) => {
-  const codingRegions = exons.filter(region => region.feature_type === 'CDS')
-  return lookupCoverageByIntervalsWithBuckets({ elasticClient, index, intervals: codingRegions, chrom })
 }

--- a/packages/api/src/schema/types/gene.js
+++ b/packages/api/src/schema/types/gene.js
@@ -8,12 +8,6 @@ import {
   GraphQLFloat,
 } from 'graphql'
 
-import coverageType, {
-  lookupCoverageByStartStop,
-  lookupCoverageBuckets,
-  lookupCoverageByIntervals,
-  lookupCoverageByIntervalsWithBuckets,
-} from './coverage'
 import variantType, {
   lookupVariantsByGeneId,
 } from './variant'
@@ -53,54 +47,6 @@ const geneType = new GraphQLObjectType({
     xstop: { type: GraphQLFloat },
     xstart: { type: GraphQLFloat },
     gene_name: { type: GraphQLString },
-    // exome_coverage: {
-    //   type: new GraphQLList(coverageType),
-    //   resolve: (obj, args, ctx) =>
-    //     lookupCoverageByStartStop(ctx.database.gnomad, 'exome_coverage', obj.xstart, obj.xstop),
-    // },
-    genome_coverage: {
-      type: new GraphQLList(coverageType),
-      resolve: (obj, args, ctx) => {
-        // if ((obj.stop - obj.start) > 1000) {
-        //   return lookupCoverageBuckets({
-        //     elasticClient: ctx.database.elastic,
-        //     index: 'genome_coverage',
-        //     intervals: [{ start: obj.start, stop: obj.stop }],
-        //     chrom: obj.chrom,
-        //   })
-        // }
-        return lookupCoverageByIntervalsWithBuckets({
-          elasticClient: ctx.database.elastic,
-          index: 'genome_coverage',
-          intervals: [{ start: obj.start, stop: obj.stop }],
-          chrom: obj.chrom,
-        })
-      }
-    },
-    exome_coverage: {
-      type: new GraphQLList(coverageType),
-      resolve: (obj, args, ctx) => {
-        if ((obj.stop - obj.start) > 10000) {
-          return lookupCoverageBuckets({
-            elasticClient: ctx.database.elastic,
-            index: 'genome_coverage',
-            intervals: [{ start: obj.start, stop: obj.stop }],
-            chrom: obj.chrom,
-          })
-        }
-        return lookupCoverageByIntervals({
-          elasticClient: ctx.database.elastic,
-          index: 'exome_coverage',
-          intervals: [{ start: obj.start, stop: obj.stop }],
-          chrom: obj.chrom,
-        })
-      }
-    },
-    // exacv1_coverage: {
-    //   type: new GraphQLList(coverageType),
-    //   resolve: (obj, args, ctx) =>
-    //     lookupCoverageByStartStop(ctx.database.exacv1, 'base_coverage', obj.xstart, obj.xstop),
-    // },
     exome_variants: {
       type: new GraphQLList(variantType),
       args: { consequence: { type: GraphQLString } },

--- a/packages/api/src/schema/types/region.js
+++ b/packages/api/src/schema/types/region.js
@@ -10,7 +10,6 @@ import {
 } from 'graphql'
 
 import coverageType, {
-  lookupCoverageByStartStop,
   lookupCoverageByIntervals,
   lookupCoverageBuckets,
 } from './coverage'

--- a/packages/api/src/schema/types/transcript.js
+++ b/packages/api/src/schema/types/transcript.js
@@ -8,7 +8,7 @@ import {
   GraphQLFloat,
 } from 'graphql'
 
-import coverageType, { lookUpCoverageByExons, lookUpCoverageByExonsWithBuckets } from './coverage'
+import coverageType, { lookUpCoverageByExons } from './coverage'
 import variantType, { lookupVariantsByTranscriptId } from './variant'
 import exonType, { lookupExonsByTranscriptId } from './exon'
 import * as fromGtex from './gtex'
@@ -86,32 +86,6 @@ const transcriptType = new GraphQLObjectType({
         })
       }
     },
-    // genome_coverage: {
-    //   type: new GraphQLList(coverageType),
-    //   resolve: (obj, args, ctx) => {
-    //     return lookupExonsByTranscriptId(ctx.database.gnomad, obj.transcript_id).then((exons) => {
-    //       return lookUpCoverageByExonsWithBuckets({
-    //         elasticClient: ctx.database.elastic,
-    //         index: 'genome_coverage',
-    //         exons,
-    //         chrom: obj.chrom
-    //       })
-    //     })
-    //   }
-    // },
-    // exome_coverage: {
-    //   type: new GraphQLList(coverageType),
-    //   resolve: (obj, args, ctx) => {
-    //     return lookupExonsByTranscriptId(ctx.database.gnomad, obj.transcript_id).then((exons) => {
-    //       return lookUpCoverageByExonsWithBuckets({
-    //         elasticClient: ctx.database.elastic,
-    //         index: 'exome_coverage',
-    //         exons,
-    //         chrom: obj.chrom
-    //       })
-    //     })
-    //   }
-    // },
     gtex_tissue_tpms_by_transcript: {
       type: fromGtex.tissuesByTranscript,
       resolve: (obj, args, ctx) =>

--- a/packages/region/test/get-test-data.js
+++ b/packages/region/test/get-test-data.js
@@ -15,14 +15,6 @@ const geneQuery = geneName => `
     gene_name
     start
     stop
-    exome_coverage {
-      pos
-      mean
-    }
-    genome_coverage {
-      pos
-      mean
-    }
     transcript {
       exons {
         feature_type

--- a/packages/utilities/src/coordinates/test/get-test-data.js
+++ b/packages/utilities/src/coordinates/test/get-test-data.js
@@ -24,14 +24,6 @@ const geneQuery = geneName => `
       gene_name
       start
       stop
-      exome_coverage {
-        pos
-        mean
-      }
-      genome_coverage {
-        pos
-        mean
-      }
       transcript {
         exons {
           feature_type

--- a/packages/utilities/src/fetch/index.js
+++ b/packages/utilities/src/fetch/index.js
@@ -12,14 +12,6 @@ export const fetchAllByGeneName = (geneName, url = API_URL) => {
       gene_name
       start
       stop
-      exome_coverage {
-        pos
-        mean
-      }
-      genome_coverage {
-        pos
-        mean
-      }
       transcript {
         exons {
           feature_type


### PR DESCRIPTION
Coverage is currently queried from the `transcript` field of genes, not from the gene itself. Remove the unused field from gene and remove unused coverage lookup functions.