### PR TITLE
Remove Mongo variant queries from API

### DIFF
--- a/packages/api/src/schema/types/gene.js
+++ b/packages/api/src/schema/types/gene.js
@@ -8,9 +8,6 @@ import {
   GraphQLFloat,
 } from 'graphql'
 
-import variantType, {
-  lookupVariantsByGeneId,
-} from './variant'
 import transcriptType, { lookupTranscriptsByTranscriptId, lookupAllTranscriptsByGeneId } from './transcript'
 import exonType, { lookupExonsByGeneId } from './exon'
 import constraintType, { lookUpConstraintByTranscriptId } from './constraint'
@@ -45,12 +42,6 @@ const geneType = new GraphQLObjectType({
     xstop: { type: GraphQLFloat },
     xstart: { type: GraphQLFloat },
     gene_name: { type: GraphQLString },
-    exome_variants: {
-      type: new GraphQLList(variantType),
-      args: { consequence: { type: GraphQLString } },
-      resolve: (obj, args, ctx) =>
-          lookupVariantsByGeneId(ctx.database.gnomad, 'exome_variants', obj.gene_id, args.consequence),
-    },
     gnomadExomeVariants: {
       type: new GraphQLList(elasticVariantType),
       args: {

--- a/packages/api/src/schema/types/region.js
+++ b/packages/api/src/schema/types/region.js
@@ -14,8 +14,6 @@ import coverageType, {
   lookupCoverageBuckets,
 } from './coverage'
 
-import variantType, { lookupVariantsByStartStop } from './variant'
-
 import elasticVariantType, {
   lookupElasticVariantsByInterval,
   lookupElasticVariantsInRegion,

--- a/packages/api/src/schema/types/transcript.js
+++ b/packages/api/src/schema/types/transcript.js
@@ -9,7 +9,6 @@ import {
 } from 'graphql'
 
 import coverageType, { lookUpCoverageByExons } from './coverage'
-import variantType, { lookupVariantsByTranscriptId } from './variant'
 import exonType, { lookupExonsByTranscriptId } from './exon'
 import * as fromGtex from './gtex'
 
@@ -26,16 +25,6 @@ const transcriptType = new GraphQLObjectType({
     gene_id: { type: GraphQLString },
     gene_name: { type: GraphQLString },
     xstop: { type: GraphQLFloat },
-    exome_variants: {
-      type: new GraphQLList(variantType),
-      resolve: (obj, args, ctx) =>
-          lookupVariantsByTranscriptId(ctx.database.gnomad, 'exome_variants', obj.transcript_id),
-    },
-    genome_variants: {
-      type: new GraphQLList(variantType),
-      resolve: (obj, args, ctx) =>
-        lookupVariantsByTranscriptId(ctx.database.gnomad, 'genome_variants', obj.transcript_id),
-    },
     exons: {
       type: new GraphQLList(exonType),
       resolve: (obj, args, ctx) =>

--- a/packages/api/src/schema/types/variant.js
+++ b/packages/api/src/schema/types/variant.js
@@ -10,8 +10,6 @@ import {
   GraphQLBoolean,
 } from 'graphql'
 
-import CATEGORY_DEFINITIONS from '@broad/utilities/src/constants/categoryDefinitions'
-
 import vepType from './vep'
 import populationType from './populations'
 import qualityMetricsType from './qualityMetrics'
@@ -86,30 +84,6 @@ export const lookupVariant = (db, collection, variant_id) => {
 export const lookupVariantRsid = (db, collection, rsid) => {
   return db.collection(collection).findOne({ rsid })
 }
-
-export const lookupVariantsByGeneId = (db, collection, gene_id, consequence) => {
-  if (consequence) {
-    return db.collection(collection).find({
-      genes: gene_id,
-      vep_annotations: {
-        '$elemMatch': {
-          'Consequence': {
-            '$in': CATEGORY_DEFINITIONS[consequence],
-          },
-        },
-      },
-    }).toArray()
-  }
-  return db.collection(collection).find({ genes: gene_id }).toArray()
-}
-
-export const lookupVariantsByTranscriptId = (db, collection, transcript_id) =>
-  db.collection(collection).find({ transcripts: transcript_id }).toArray()
-
-export const lookupVariantsByStartStop = (db, collection, xstart, xstop) =>
-  db.collection(collection).find(
-    { xpos: { '$gte': Number(xstart), '$lte': Number(xstop) } }
-  ).toArray()
 
 export const variantResolver = (obj, args, ctx) => {  // eslint-disable-line
   let database

--- a/packages/gene-page/src/tests/getTestData.js
+++ b/packages/gene-page/src/tests/getTestData.js
@@ -11,22 +11,6 @@ export const fetchData = (geneName, url = API_URL) => {
       gene_name
       xstart
       xstop
-      exome_variants {
-        variant_id
-        pos
-        xpos
-        allele_count
-        allele_freq
-        filter
-      }
-      genome_variants {
-        variant_id
-        pos
-        xpos
-        allele_count
-        allele_freq
-        filter
-      }
   }
 }
 `

--- a/packages/region/test/get-test-data.js
+++ b/packages/region/test/get-test-data.js
@@ -33,43 +33,6 @@ const geneQuery = geneName => `
       chrom
       gene_id
     }
-    exome_variants {
-      chrom
-      pos
-      ref
-      alt
-      variant_id
-      allele_num
-      allele_freq
-      allele_count
-      hom_count
-    }
-    genome_variants {
-      chrom
-      pos
-      ref
-      alt
-      variant_id
-      allele_num
-      allele_freq
-      allele_count
-      hom_count
-    }
-    exacv1_coverage {
-      pos
-      mean
-    }
-    exacv1_variants {
-      chrom
-      pos
-      ref
-      alt
-      variant_id
-      allele_num
-      allele_freq
-      allele_count
-      hom_count
-    }
 }}
 `
 export const testGenes = [

--- a/packages/utilities/src/fetch/index.js
+++ b/packages/utilities/src/fetch/index.js
@@ -30,28 +30,6 @@ export const fetchAllByGeneName = (geneName, url = API_URL) => {
         chrom
         gene_id
       }
-      exome_variants {
-        chrom
-        pos
-        ref
-        alt
-        variant_id
-        allele_num
-        allele_freq
-        allele_count
-        hom_count
-      }
-      genome_variants {
-        chrom
-        pos
-        ref
-        alt
-        variant_id
-        allele_num
-        allele_freq
-        allele_count
-        hom_count
-      }
   }
 }`
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
The `exome_variants` and `genome_variants` fields on the gene and transcript types load variants from Mongo. The gnomAD browser uses the `gnomadExomeVariants` and `gnomadGenomeVariants` fields, which load variants from Elasticsearch. To standardize on a data source for variants, this change removes the unused Mongo-backed fields.