### PR TITLE
Fix region viewer scale to account for points that fall between two regions

### DIFF
--- a/packages/utilities/src/coordinates/index.js
+++ b/packages/utilities/src/coordinates/index.js
@@ -155,10 +155,27 @@ export const calculateOffsetRegions = (
 
 export const calculatePositionOffset = R.curry((regions, position) => {
   const lastRegionBeforePosition = R.findLast(region => region.start <= position)(regions)
-  const region = R.defaultTo(regions[0])(lastRegionBeforePosition)
+
+  if (lastRegionBeforePosition) {
+    // Position is within a region
+    if (position < lastRegionBeforePosition.stop) {
+      return {
+        offsetPosition: position - lastRegionBeforePosition.offset,
+        color: lastRegionBeforePosition.color,
+      }
+    }
+
+    // Position is between regions
+    return {
+      offsetPosition: lastRegionBeforePosition.stop - lastRegionBeforePosition.offset,
+      color: lastRegionBeforePosition.color,
+    }
+  }
+
+  // Position is before first region
   return {
-    offsetPosition: position - region.offset,
-    color: region.color,
+    offsetPosition: regions[0].start - regions[0].offset,
+    color: regions[0].color,
   }
 })
 


### PR DESCRIPTION
Some ClinVar variants may fall between the regions plotted in the region viewer. Currently, if a variant's position falls between two regions, its offset will be based on the first region and thus its scaled x position will be _way_ outside the region viewer to the right. With this change, it will be positioned correctly between the two regions.