### PR TITLE
Revert "Allow interaction with tooltip content"

### DIFF
--- a/packages/ui/src/tooltip/withTooltip.js
+++ b/packages/ui/src/tooltip/withTooltip.js
@@ -8,22 +8,6 @@ import { InnerPopper } from 'react-popper/lib/cjs/Popper'
 import { Arrow, Container } from './styles'
 
 
-const rectUnion = (rect1, rect2) => ({
-  bottom: Math.max(rect1.bottom, rect2.bottom),
-  left: Math.min(rect1.left, rect2.left),
-  right: Math.max(rect1.right, rect2.right),
-  top: Math.min(rect1.top, rect2.top),
-})
-
-
-const isPointInRect = (rect, point) => (
-  rect.bottom >= point.y
-  && rect.left <= point.x
-  && rect.right >= point.x
-  && rect.top <= point.y
-)
-
-
 class TooltipAnchor extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
@@ -40,54 +24,16 @@ class TooltipAnchor extends Component {
     this.removeTooltip()
   }
 
-  onMouseEnter = () => {
-    this.cancelTooltipRemoval()
-    this.renderTooltipInPortal()
-  }
-
-  onMouseLeave = (e) => {
-    // The user may want to interact with tooltip content, select tooltip text, etc.
-    // If the mouse is moving towards the tooltip element when it leaves the anchor element,
-    // allow some time for it to reach the tooltip before the tooltip is removed.
-    // The tooltip's removal will be canceled once the mouse enters the tooltip element.
-
-    // Approximate "is mouse moving towards tooltip" by checking if the mouse is contained
-    // in the union of the bounding boxes of the tooltip and anchor elements.
-    const tooltipBounds = this.containerElement.firstChild.getBoundingClientRect()
-    const anchorBounds = this.referenceElement.getBoundingClientRect()
-    const totalBounds = rectUnion(tooltipBounds, anchorBounds)
-    const mouseLocation = { x: e.clientX, y: e.clientY }
-
-    if (isPointInRect(totalBounds, mouseLocation)) {
-      this.scheduleTooltipRemoval()
-    } else {
-      this.removeTooltip()
-    }
-  }
-
   referenceElementRef = (el) => {
     this.referenceElement = el
   }
 
-  removeTooltip() {
-    this.cancelTooltipRemoval()
+  removeTooltip = () => {
     if (this.containerElement) {
       ReactDOM.unmountComponentAtNode(this.containerElement)
       document.body.removeChild(this.containerElement)
       this.containerElement = null
     }
-  }
-
-  cancelTooltipRemoval() {
-    if (this.removeTooltipTimeout) {
-      clearTimeout(this.removeTooltipTimeout)
-      this.removeTooltipTimeout = null
-    }
-  }
-
-  scheduleTooltipRemoval() {
-    this.cancelTooltipRemoval()
-    this.removeTooltipTimeout = setTimeout(() => this.removeTooltip(), 100)
   }
 
   renderTooltipContent = ({ ref, style, placement, arrowProps }) => {
@@ -99,20 +45,14 @@ class TooltipAnchor extends Component {
     } = this.props
 
     return (
-      <Container
-        data-placement={placement}
-        innerRef={ref}
-        onMouseEnter={this.onMouseEnter}
-        onMouseLeave={this.onMouseLeave}
-        style={style}
-      >
+      <Container data-placement={placement} innerRef={ref} style={style}>
         <TooltipComponent {...otherProps} />
         <Arrow data-placement={placement} innerRef={arrowProps.ref} style={arrowProps.style} />
       </Container>
     )
   }
 
-  renderTooltipInPortal() {
+  renderTooltipInPortal = () => {
     if (!this.containerElement) {
       this.containerElement = document.createElement('div')
       document.body.appendChild(this.containerElement)
@@ -138,8 +78,8 @@ class TooltipAnchor extends Component {
     return React.cloneElement(
       React.Children.only(this.props.children),
       {
-        onMouseEnter: this.onMouseEnter,
-        onMouseLeave: this.onMouseLeave,
+        onMouseEnter: this.renderTooltipInPortal,
+        onMouseLeave: this.removeTooltip,
         ref: this.referenceElementRef,
       }
     )


### PR DESCRIPTION
This reverts commit 94b8527f197da48a6c4eeefe34ce1b9a0b385748.

This was originally done so that a link could be placed in the tooltip for the ClinVar track. However, that results in the tooltip getting in the way when trying to mouse around the variants (to see a variant above the currently hovered variant, you have to move the mouse down, wait for the tooltip, then move the mouse up to the desired variant). I think it's preferable to directly click on a variant to navigate to ClinVar vs hover over a variant and then click a link in the tooltip.