### PR TITLE
Remove unused dependencies from API package

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -30,16 +30,12 @@
     "express": "^4.14.0",
     "express-graphql": "^0.5.4",
     "graphql": "^0.7.2",
-    "graphql-tester": "0.0.5",
     "graphql-type-json": "0.1.4",
     "immutable": "^4.0.0-rc.9",
     "ioredis": "^3.1.4",
-    "isomorphic-fetch": "^2.2.1",
     "lodash.camelcase": "^4.3.0",
-    "lodash.capitalize": "^4.2.1",
     "lodash.snakecase": "^4.1.1",
-    "mongodb": "^2.2.11",
-    "ramda": "^0.22.1"
+    "mongodb": "^2.2.11"
   },
   "devDependencies": {
     "nodemon": "^1.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4144,10 +4144,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-freeport@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/freeport/-/freeport-1.0.5.tgz#255e8ab84170c33ba85d990e821ae5f4a1a9bc5d"
-
 fresh@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
@@ -4414,13 +4410,6 @@ graphql-request@^1.4.0:
 graphql-tag@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.5.0.tgz#b43bfd8b5babcd2c205ad680c03e98b238934e0f"
-
-graphql-tester@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/graphql-tester/-/graphql-tester-0.0.5.tgz#570c2f114c319ac1389c4312796db39d5223af65"
-  dependencies:
-    freeport "^1.0.5"
-    request "^2.69.0"
 
 graphql-type-json@0.1.4:
   version "0.1.4"
@@ -5778,10 +5767,6 @@ lodash.bind@^4.2.1:
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-
-lodash.capitalize@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
 
 lodash.clone@^4.5.0:
   version "4.5.0"
@@ -7937,10 +7922,6 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
-ramda@^0.22.1:
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.22.1.tgz#031da0c3df417c5b33c96234757eb37033f36a0e"
-
 ramda@^0.24.1:
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
@@ -8587,7 +8568,7 @@ request-progress@^2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@^2.52.0, request@^2.69.0:
+request@^2.52.0:
   version "2.85.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
   dependencies:


### PR DESCRIPTION
Since these dependencies are never used, there is no need to include them in the Docker image.