### PR TITLE
Fixup API dependencies

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,6 +22,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "compression": "^1.7.1",
     "core-js": "^2.5.0",
     "cors": "^2.8.1",

--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -1,4 +1,3 @@
-import 'babel-core/register'
 import 'babel-polyfill'
 import express from 'express'
 import compression from 'compression'


### PR DESCRIPTION
#186 broke the API when running in Docker.

This restores `babel-polyfill` to api's package.json and marks it as a dependency (not a devDependency).

Also removes the dependency on `babel-core/register`. Since we compile files ahead of time, there is no need for it.

https://github.com/macarthur-lab/gnomadjs/blob/0685e14fd2e474c64b80f4ea8991069f98c2c6f1/packages/api/deploy/Makefile#L35-L39