### PR TITLE
Update API Docker build

### DIFF
--- a/packages/api/.dockerignore
+++ b/packages/api/.dockerignore
@@ -1,0 +1,3 @@
+*
+!build
+!package.json

--- a/packages/api/deploy/dockerfiles/gnomadgraphql.dockerfile
+++ b/packages/api/deploy/dockerfiles/gnomadgraphql.dockerfile
@@ -2,10 +2,6 @@ FROM gcr.io/exac-gnomad/gnomad-api-base
 
 MAINTAINER MacArthur Lab
 
-# ENV NODE_ENV=production GRAPHQL_PORT=8000 MONGO_URL=mongodb://localhost:27017/exac
+COPY build /var/www/build
 
-COPY . /var/www
-WORKDIR /var/www
-
-ENTRYPOINT ["npm"]
-CMD ["run", "docker"]
+CMD ["node", "build/server.js"]

--- a/packages/api/deploy/dockerfiles/gnomadgraphqlbase.dockerfile
+++ b/packages/api/deploy/dockerfiles/gnomadgraphqlbase.dockerfile
@@ -2,11 +2,8 @@ FROM node:7.5.0
 
 MAINTAINER MacArthur Lab
 
-# ENV NODE_ENV=production GRAPHQL_PORT=8000 MONGO_URL=mongodb://localhost:27017/exac
-
-COPY package.json /var/www/
-
 WORKDIR /var/www
 
+COPY package.json /var/www/
 
 RUN npm install --production

--- a/packages/api/deploy/dockerfiles/gnomadgraphqlbase.dockerfile
+++ b/packages/api/deploy/dockerfiles/gnomadgraphqlbase.dockerfile
@@ -8,16 +8,5 @@ COPY package.json /var/www/
 
 WORKDIR /var/www
 
-# Install development dependencies too
-RUN npm install
 
-# RUN npm run build
-
-COPY lib/utilities/ /var/www/node_modules/@broad/utilities
-COPY lib/utilities/ /var/www/node_modules/@broad/utilities
-WORKDIR /var/www/node_modules/@broad/utilities
-RUN npm install
-WORKDIR /var/www
-
-# RUN ls /var/www/node_modules
-RUN ls /var/www/node_modules/@broad
+RUN npm install --production

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,7 +15,6 @@
     "vm": "nodemon --exec GRAPHQL_PORT=8000 MONGO_URL=mongodb://localhost:27017/exac babel-node src/server.js --max_old_space_size=4096",
     "prod": "GRAPHQL_PORT=8000 MONGO_URL=mongodb://localhost:27017/exac node --max_old_space_size=65536  build/server.js",
     "flush": "redis-cli flushall",
-    "docker": "node build/server.js",
     "mappings": "curl -XGET 'elastic:9200/*/_mapping?pretty' > src/elastic-mappings/mappings.json"
   },
   "keywords": [],


### PR DESCRIPTION
* Remove `@broad/utilities` package
* Remove unnecessary files from image

Along with #187, this reduces the Docker image size by ~100MB