### PR TITLE
Add gnomAD read data to API

### DIFF
--- a/packages/api/.eslintrc.js
+++ b/packages/api/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    browser: false,
+    node: true,
+  },
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -35,7 +35,9 @@
     "ioredis": "^3.1.4",
     "lodash.camelcase": "^4.3.0",
     "lodash.snakecase": "^4.1.1",
-    "mongodb": "^2.2.11"
+    "mongodb": "^2.2.11",
+    "serve-static": "^1.13.2",
+    "sqlite": "^3.0.0"
   },
   "devDependencies": {
     "nodemon": "^1.11.0"

--- a/packages/api/src/schema/datasets/gnomad.js
+++ b/packages/api/src/schema/datasets/gnomad.js
@@ -36,12 +36,12 @@ export const GnomadVariantType = new GraphQLObjectType({
           qualityMetrics: { type: VariantQualityMetricsType },
           reads: {
             type: ReadsType,
-            resolve: obj => {
+            resolve: async obj => {
               if (!process.env.READS_DIR) {
                 return null
               }
               try {
-                return resolveReads(process.env.READS_DIR, 'combined_bams_exomes', obj)
+                return await resolveReads(process.env.READS_DIR, 'combined_bams_exomes', obj)
               } catch (err) {
                 throw Error('Unable to load reads data')
               }
@@ -61,12 +61,12 @@ export const GnomadVariantType = new GraphQLObjectType({
           qualityMetrics: { type: VariantQualityMetricsType },
           reads: {
             type: ReadsType,
-            resolve: obj => {
+            resolve: async obj => {
               if (!process.env.READS_DIR) {
                 return null
               }
               try {
-                return resolveReads(process.env.READS_DIR, 'combined_bams_genomes', obj)
+                return await resolveReads(process.env.READS_DIR, 'combined_bams_genomes', obj)
               } catch (err) {
                 throw Error('Unable to load reads data')
               }

--- a/packages/api/src/schema/datasets/shared/reads.js
+++ b/packages/api/src/schema/datasets/shared/reads.js
@@ -1,0 +1,79 @@
+import path from 'path'
+
+import { GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString } from 'graphql'
+import sqlite from 'sqlite' // eslint-disable-line import/extensions
+
+const ReadsCategoryType = new GraphQLObjectType({
+  name: 'ReadsCategory',
+  fields: {
+    available: { type: GraphQLInt },
+    expected: { type: GraphQLInt },
+    readGroups: { type: new GraphQLList(GraphQLString) },
+  },
+})
+
+export const ReadsType = new GraphQLObjectType({
+  name: 'Reads',
+  fields: {
+    het: { type: ReadsCategoryType },
+    hom: { type: ReadsCategoryType },
+    hemi: { type: ReadsCategoryType },
+    bamPath: { type: GraphQLString },
+    indexPath: { type: GraphQLString },
+  },
+})
+
+export const resolveReads = async (readsRootDir, subDir, { alt, chrom, pos, ref }) => {
+  const dbPath = path.join(
+    readsRootDir,
+    subDir,
+    'combined_bams',
+    chrom,
+    `combined_chr${chrom}_${`${pos % 1000}`.padStart(3, '0')}.db`
+  )
+
+  const db = await sqlite.open(dbPath)
+  const rows = await db.all(
+    'select n_expected_samples, n_available_samples, het_or_hom_or_hemi from t where chrom = ? and pos = ? and ref = ? and alt = ?',
+    chrom,
+    pos,
+    ref,
+    alt
+  )
+  await db.close()
+
+  const bamPath = [
+    'reads',
+    subDir,
+    'combined_bams',
+    chrom,
+    `combined_chr${chrom}_${`${pos % 1000}`.padStart(3, '0')}.bam`,
+  ].join('/')
+
+  const indexPath = `${bamPath}.bai`
+
+  const reads = {
+    bamPath,
+    indexPath,
+  }
+  ;['het', 'hom', 'hemi'].forEach(category => {
+    const row = rows.find(r => r.het_or_hom_or_hemi === category)
+    if (!row) {
+      reads[category] = {
+        available: 0,
+        expected: 0,
+        readGroups: [],
+      }
+    } else {
+      reads[category] = {
+        available: row.n_available_samples,
+        expected: row.n_expected_samples,
+        readGroups: [...Array(row.n_available_samples)].map(
+          (_, i) => `${chrom}-${pos}-${ref}-${alt}_${category}${i}`
+        ),
+      }
+    }
+  })
+
+  return reads
+}

--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -6,6 +6,7 @@ import elasticsearch from 'elasticsearch'
 import graphQLHTTP from 'express-graphql'
 import cors from 'cors'
 import Redis from 'ioredis'
+import serveStatic from 'serve-static'
 
 import gnomadSchema from './schema'
 
@@ -42,10 +43,11 @@ app.use(cors());
         },
       },
     }))
-    app.use('/export', (request, response) => {
-      console.log(request)
-      response.send('hello!')
-    })
+
+    if (process.env.READS_DIR) {
+      app.use('/reads', serveStatic(process.env.READS_DIR, { acceptRanges: true }))
+    }
+
     app.listen(process.env.GRAPHQL_PORT, () =>
       console.log(`Listening on ${process.env.GRAPHQL_PORT}`))
   } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7003,7 +7003,7 @@ nan@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
-nan@^2.9.2:
+nan@^2.9.2, nan@~2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -7135,7 +7135,7 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@^0.10.0:
+node-pre-gyp@^0.10.0, node-pre-gyp@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
   dependencies:
@@ -9719,7 +9719,7 @@ serve-static@1.12.4:
     parseurl "~1.3.1"
     send "0.15.4"
 
-serve-static@1.13.2:
+serve-static@1.13.2, serve-static@^1.13.2:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.2.tgz#095e8472fd5b46237db50ce486a43f4b86c6cec1"
   dependencies:
@@ -10083,6 +10083,26 @@ sprintf-js@1.1.1:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+sql-template-strings@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/sql-template-strings/-/sql-template-strings-2.2.2.tgz#3f11508a25addfce217a3042a9d300c3193b96ff"
+
+sqlite3@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.0.2.tgz#1bbeb68b03ead5d499e42a3a1b140064791c5a64"
+  dependencies:
+    nan "~2.10.0"
+    node-pre-gyp "^0.10.3"
+    request "^2.87.0"
+
+sqlite@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/sqlite/-/sqlite-3.0.0.tgz#94b70b6d1e837b1dff6881d393776ff609383c5c"
+  dependencies:
+    sqlite3 "^4.0.0"
+  optionalDependencies:
+    sql-template-strings "^2.2.2"
 
 sshpk@^1.7.0:
   version "1.13.1"


### PR DESCRIPTION
Requires `READS_DIR` environment variable to be set in the production deployment.

For local development, `READS_DIR` can be left unset. In that case, the API will still function and the`reads` fields on gnomAD variants will be null.