### PR TITLE
Add some basic UI components

### DIFF
--- a/packages/ui/src/Badge.js
+++ b/packages/ui/src/Badge.js
@@ -1,0 +1,48 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+import { TooltipAnchor } from './tooltip/TooltipAnchor'
+
+const TextTooltip = ({ text }) => <span>{text}</span>
+
+TextTooltip.propTypes = {
+  text: PropTypes.string.isRequired,
+}
+
+const BADGE_COLOR = {
+  error: '#DD2C00',
+  info: '#424242',
+  success: '#2E7D32',
+  warning: 'orange',
+}
+
+const BadgeWrapper = styled.span`
+  padding: 0.25em 0.4em;
+  border: 1px solid #000;
+  border-radius: 0.3em;
+  background: ${props => BADGE_COLOR[props.level]};
+  color: ${props => (props.level === 'warning' ? '#000' : '#fff')};
+  font-size: 0.75em;
+  font-weight: bold;
+`
+
+export const Badge = ({ children, level, tooltip }) =>
+  tooltip ? (
+    <TooltipAnchor childRefPropName="innerRef" text={tooltip} tooltipComponent={TextTooltip}>
+      <BadgeWrapper level={level}>{children}</BadgeWrapper>
+    </TooltipAnchor>
+  ) : (
+    <BadgeWrapper level={level}>{children}</BadgeWrapper>
+  )
+
+Badge.propTypes = {
+  children: PropTypes.string.isRequired,
+  level: PropTypes.oneOf(['error', 'info', 'success', 'warning']),
+  tooltip: PropTypes.string,
+}
+
+Badge.defaultProps = {
+  level: 'info',
+  tooltip: undefined,
+}

--- a/packages/ui/src/Button.js
+++ b/packages/ui/src/Button.js
@@ -1,0 +1,72 @@
+import { darken, transparentize } from 'polished'
+import styled from 'styled-components'
+
+export const BaseButton = styled.button.attrs({
+  type: 'button',
+})`
+  padding: 0.375em 0.75em;
+  border-color: ${props => props.borderColor};
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: ${props => props.backgroundColor};
+  color: ${props => props.textColor};
+  cursor: pointer;
+  font-size: 1em;
+  outline: none;
+  user-select: none;
+
+  &:active,
+  &:hover {
+    background-color: ${props => darken(0.15, props.backgroundColor)};
+  }
+
+  &:disabled {
+    background-color: ${props => transparentize(0.5, props.backgroundColor)};
+    cursor: not-allowed;
+  }
+
+  &:focus {
+    box-shadow: ${props => `0 0 0 0.2em ${transparentize(0.5, props.borderColor)}`};
+  }
+`
+
+/* stylelint-disable block-no-empty */
+export const Button = styled(BaseButton).attrs({
+  backgroundColor: '#f8f9fa',
+  borderColor: '#6c757d',
+})``
+
+export const PrimaryButton = styled(BaseButton).attrs({
+  backgroundColor: '#428bca',
+  borderColor: '#428bca',
+  textColor: '#fff',
+})``
+/* stylelint-enable block-no-empty */
+
+export const TextButton = styled.button.attrs({
+  type: 'button',
+})`
+  padding: 0;
+  border: none;
+  background: none;
+  color: #428bca;
+  cursor: pointer;
+  font-size: 1em;
+  outline: none;
+  user-select: none;
+
+  &:active,
+  &:hover {
+    color: #be4248;
+  }
+
+  &:disabled {
+    color: ${transparentize(0.5, '#428bca')};
+    cursor: not-allowed;
+  }
+
+  &:focus {
+    text-decoration: underline;
+  }
+`

--- a/packages/ui/src/Checkbox.js
+++ b/packages/ui/src/Checkbox.js
@@ -1,0 +1,38 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+const Label = styled.label`
+  user-select: none;
+`
+
+const CheckboxInput = styled.input`
+  margin-right: 0.5em;
+`
+
+export const Checkbox = ({ checked, disabled, id, label, onChange }) => (
+  <Label htmlFor={id}>
+    <CheckboxInput
+      checked={checked}
+      disabled={disabled}
+      id={id}
+      onChange={e => {
+        onChange(e.target.checked)
+      }}
+      type="checkbox"
+    />
+    {label}
+  </Label>
+)
+
+Checkbox.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+}
+
+Checkbox.defaultProps = {
+  disabled: false,
+}

--- a/packages/ui/src/Link.js
+++ b/packages/ui/src/Link.js
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+export const Link = styled.a`
+  color: #428bca;
+  text-decoration: none;
+
+  &:active,
+  &:hover {
+    color: #be4248;
+  }
+
+  &:focus {
+    text-decoration: underline;
+  }
+
+  &:visited {
+    color: #428bca;
+  }
+`
+
+export const ExternalLink = props => {
+  const { children, ...rest } = props
+  return (
+    <Link {...rest} rel="noopener" target="_blank">
+      {children}
+    </Link>
+  )
+}
+
+ExternalLink.propTypes = {
+  children: PropTypes.node.isRequired,
+}

--- a/packages/ui/src/List.js
+++ b/packages/ui/src/List.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+
+export const List = styled.ul`
+  padding-left: 20px;
+  list-style-type: disc;
+  margin-bottom: 1em;
+`
+
+export const ListItem = styled.li`
+  margin-bottom: 0.5em;
+`
+
+export const OrderedList = List.withComponent('ol')

--- a/packages/ui/src/Page.js
+++ b/packages/ui/src/Page.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+
+export const Page = styled.div`
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 1200px;
+  padding: 0 15px;
+  margin: 0 auto 40px;
+  font-size: 14px;
+`
+
+export const PageHeading = styled.h1`
+  padding-bottom: 0.5em;
+  border-bottom: 1px solid #ccc;
+  margin: 0.5em 0 1em;
+  font-size: 36px;
+`
+
+export const SectionHeading = styled.h2`
+  margin: 0 0 0.5em;
+  font-size: 24px;
+`

--- a/packages/ui/src/SegmentedControl.js
+++ b/packages/ui/src/SegmentedControl.js
@@ -3,29 +3,29 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import styled from 'styled-components'
 
-
 const SegmentedControlContainer = styled.span`
-  background-color: ${props => props.backgroundColor};
-  border-color: ${props => props.borderColor};
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 0.5em;
-  box-shadow: ${props => props.isFocused ? `0 0 0 0.2em ${transparentize(0.5, props.borderColor)}` : 'none'};
-  color: ${props => props.textColor};
+  position: relative;
   display: inline-flex;
   flex-direction: row;
   justify-content: space-between;
-  position: relative;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.5em;
+  background-color: ${props => props.backgroundColor};
+  border-color: ${props => props.borderColor};
+  box-shadow: ${props =>
+    props.isFocused ? `0 0 0 0.2em ${transparentize(0.5, props.borderColor)}` : 'none'};
+  color: ${props => props.textColor};
   user-select: none;
 
   input {
-    ${hideVisually()}
+    ${hideVisually()};
   }
 
   label {
+    padding: 0.375em 0.75em;
     border: 1px solid transparent;
     cursor: pointer;
-    padding: 0.375em 0.75em;
 
     &:first-of-type {
       border-bottom-left-radius: 0.5em;
@@ -39,10 +39,9 @@ const SegmentedControlContainer = styled.span`
   }
 
   input:checked + label {
-    background-color: ${props => darken(0.15, props.backgroundColor)}
+    background-color: ${props => darken(0.15, props.backgroundColor)};
   }
 `
-
 
 export class SegmentedControl extends Component {
   static propTypes = {
@@ -55,19 +54,11 @@ export class SegmentedControl extends Component {
       PropTypes.shape({
         disabled: PropTypes.bool,
         label: PropTypes.string,
-        value: PropTypes.oneOfType([
-          PropTypes.bool,
-          PropTypes.number,
-          PropTypes.string,
-        ]),
+        value: PropTypes.oneOfType([PropTypes.bool, PropTypes.number, PropTypes.string]),
       })
     ).isRequired,
     textColor: PropTypes.string,
-    value: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.number,
-      PropTypes.string,
-    ]).isRequired,
+    value: PropTypes.oneOfType([PropTypes.bool, PropTypes.number, PropTypes.string]).isRequired,
   }
 
   static defaultProps = {
@@ -85,7 +76,7 @@ export class SegmentedControl extends Component {
     this.setState({ isFocused: false })
   }
 
-  onChange = (e) => {
+  onChange = e => {
     const selectedIndex = parseInt(e.target.value, 10)
     const selectedOption = this.props.options[selectedIndex]
     this.props.onChange(selectedOption.value)
@@ -96,15 +87,7 @@ export class SegmentedControl extends Component {
   }
 
   render() {
-    const {
-      backgroundColor,
-      borderColor,
-      disabled,
-      id,
-      options,
-      textColor,
-      value,
-    } = this.props
+    const { backgroundColor, borderColor, disabled, id, options, textColor, value } = this.props
 
     return (
       <SegmentedControlContainer
@@ -125,12 +108,9 @@ export class SegmentedControl extends Component {
             onChange={this.onChange}
             onFocus={this.onFocus}
           />,
-          <label
-            key={`${opt.value}-label`}
-            htmlFor={`segmented-control-input-${id}-${opt.value}`}
-          >
+          <label key={`${opt.value}-label`} htmlFor={`segmented-control-input-${id}-${opt.value}`}>
             {opt.label || opt.value}
-          </label>
+          </label>,
         ])}
       </SegmentedControlContainer>
     )

--- a/packages/ui/src/SegmentedControl.js
+++ b/packages/ui/src/SegmentedControl.js
@@ -12,7 +12,6 @@ const SegmentedControlContainer = styled.span`
   border-radius: 0.5em;
   box-shadow: ${props => props.isFocused ? `0 0 0 0.2em ${transparentize(0.5, props.borderColor)}` : 'none'};
   color: ${props => props.textColor};
-  cursor: pointer;
   display: inline-flex;
   flex-direction: row;
   justify-content: space-between;
@@ -25,7 +24,8 @@ const SegmentedControlContainer = styled.span`
 
   label {
     border: 1px solid transparent;
-    padding: 0.25em 0.75em;
+    cursor: pointer;
+    padding: 0.375em 0.75em;
 
     &:first-of-type {
       border-bottom-left-radius: 0.5em;

--- a/packages/ui/src/example/CheckboxExample.js
+++ b/packages/ui/src/example/CheckboxExample.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react'
+
+import { Checkbox } from '..'
+
+export default class CheckboxExample extends Component {
+  state = {
+    checked: false,
+  }
+
+  render() {
+    return (
+      <Checkbox
+        checked={this.state.checked}
+        id="example-checkbox"
+        label="Some option"
+        onChange={checked => {
+          this.setState({ checked })
+        }}
+      />
+    )
+  }
+}

--- a/packages/ui/src/example/InfoModalExample.js
+++ b/packages/ui/src/example/InfoModalExample.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react'
+
+import { Button, InfoModal } from '..'
+
+export default class InfoModalExample extends Component {
+  state = {
+    isModalOpen: false,
+  }
+
+  render() {
+    return (
+      <div>
+        <Button
+          disabled={this.state.isModalOpen}
+          onClick={() => {
+            this.setState({
+              isModalOpen: true,
+            })
+          }}
+        >
+          Open modal
+        </Button>
+
+        {this.state.isModalOpen && (
+          <InfoModal
+            onRequestClose={() => {
+              this.setState({ isModalOpen: false })
+            }}
+            title="Example modal"
+            width="500px"
+          >
+            Modal content
+          </InfoModal>
+        )}
+      </div>
+    )
+  }
+}

--- a/packages/ui/src/example/SegmentedControlExample.js
+++ b/packages/ui/src/example/SegmentedControlExample.js
@@ -2,18 +2,13 @@ import React, { Component } from 'react'
 
 import { SegmentedControl } from '..'
 
-
 export default class SegmentedControlExample extends Component {
   state = {
-    options: [
-      { value: 'foo' },
-      { value: 'bar' },
-      { value: 'baz' },
-    ],
+    options: [{ value: 'foo' }, { value: 'bar' }, { value: 'baz' }],
     value: 'foo',
   }
 
-  onChange = (value) => {
+  onChange = value => {
     this.setState({ value })
   }
 

--- a/packages/ui/src/example/TooltipExample.js
+++ b/packages/ui/src/example/TooltipExample.js
@@ -1,16 +1,18 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 
-import { withTooltip } from '..'
+import { TooltipAnchor } from '..'
 
+const BasicTooltip = ({ tooltip }) => <span>{tooltip}</span>
 
-const WithTooltip = withTooltip(props => <span>{props.tooltip}</span>)
+BasicTooltip.propTypes = {
+  tooltip: PropTypes.string.isRequired,
+}
 
-
-const TextWithTooltip = ({ text }) => (
-  <WithTooltip tooltip={text}>
-    <span>{text}</span>
-  </WithTooltip>
+const TooltipExample = () => (
+  <TooltipAnchor tooltip="A tooltip" tooltipComponent={BasicTooltip}>
+    <span>Hover here</span>
+  </TooltipAnchor>
 )
 
-
-export default () => <TextWithTooltip text="Hello world" />
+export default TooltipExample

--- a/packages/ui/src/example/index.js
+++ b/packages/ui/src/example/index.js
@@ -1,39 +1,85 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { MaterialButtonRaised } from '../index'
+import {
+  Badge,
+  Button,
+  Link,
+  List,
+  ListItem,
+  Page,
+  PageHeading,
+  PrimaryButton,
+  SectionHeading,
+  TextButton,
+} from '..'
+import CheckboxExample from './CheckboxExample'
+import InfoModalExample from './InfoModalExample'
 import SegmentedControlExample from './SegmentedControlExample'
 import TooltipExample from './TooltipExample'
 
-
-const ExampleContainer = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  margin-left: 20px;
-  margin-top: 20px;
-  height: 300px;
+const Section = styled.section`
+  margin-bottom: 2em;
 `
 
-const ExampleItem = styled.div`
-  margin-bottom: 10px;
-`
+const UiExample = () => (
+  <Page>
+    <PageHeading>UI Components</PageHeading>
 
-const UiExample = () => {
-  return (
-    <ExampleContainer>
-      <ExampleItem>
-        <MaterialButtonRaised>Raised Button</MaterialButtonRaised>
-      </ExampleItem>
-      <ExampleItem>
-        <SegmentedControlExample />
-      </ExampleItem>
-      <ExampleItem>
-        <TooltipExample />
-      </ExampleItem>
-    </ExampleContainer>
-  )
-}
+    <Section>
+      <SectionHeading>Badges</SectionHeading>
+      {['error', 'info', 'success', 'warning'].map(level => (
+        <Badge
+          key={level}
+          level={level}
+          tooltip={`${level === 'error' || level === 'info' ? 'An' : 'A'} ${level} badge`}
+        >
+          {level.charAt(0).toUpperCase() + level.slice(1)}
+        </Badge>
+      ))}
+    </Section>
+
+    <Section>
+      <SectionHeading>Buttons</SectionHeading>
+      <Button>Button</Button>
+      <PrimaryButton>Primary Button</PrimaryButton>
+      <TextButton>Text Button</TextButton>
+    </Section>
+
+    <Section>
+      <SectionHeading>Checkbox</SectionHeading>
+      <CheckboxExample />
+    </Section>
+
+    <Section>
+      <SectionHeading>Link</SectionHeading>
+      <Link href={location.href}>UI Examples</Link>
+    </Section>
+
+    <Section>
+      <SectionHeading>List</SectionHeading>
+      <List>
+        <ListItem>Foo</ListItem>
+        <ListItem>Bar</ListItem>
+        <ListItem>Baz</ListItem>
+      </List>
+    </Section>
+
+    <Section>
+      <SectionHeading>Modal</SectionHeading>
+      <InfoModalExample />
+    </Section>
+
+    <Section>
+      <SectionHeading>Segmented Control</SectionHeading>
+      <SegmentedControlExample />
+    </Section>
+
+    <Section>
+      <SectionHeading>Tooltip</SectionHeading>
+      <TooltipExample />
+    </Section>
+  </Page>
+)
 
 export default UiExample

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -73,6 +73,8 @@ export {
   InfoModal
 } from './modal/InfoModal'
 
+export { Page, PageHeading, SectionHeading } from './Page'
+
 export { SegmentedControl } from './SegmentedControl'
 
 export { TooltipAnchor } from './tooltip/TooltipAnchor'

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -61,6 +61,8 @@ export {
   ItemWrapper,
 } from './genePage/geneInfoStyles'
 
+export { Badge } from './Badge'
+
 export { Checkbox } from './Checkbox'
 
 export {

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -61,6 +61,8 @@ export {
   ItemWrapper,
 } from './genePage/geneInfoStyles'
 
+export { Checkbox } from './Checkbox'
+
 export {
   InfoModal
 } from './modal/InfoModal'

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -65,6 +65,8 @@ export { Badge } from './Badge'
 
 export { Checkbox } from './Checkbox'
 
+export { ExternalLink, Link } from './Link'
+
 export {
   InfoModal
 } from './modal/InfoModal'

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -2,6 +2,8 @@ export {
   MaterialButtonRaised,
 } from './material/button'
 
+export { BaseButton, Button, PrimaryButton, TextButton } from './Button'
+
 export {
   ClassicExacButton,
   ClassicExacButtonFirst,

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -67,6 +67,8 @@ export { Checkbox } from './Checkbox'
 
 export { ExternalLink, Link } from './Link'
 
+export { List, ListItem, OrderedList } from './List'
+
 export {
   InfoModal
 } from './modal/InfoModal'

--- a/packages/ui/src/modal/InfoModal.js
+++ b/packages/ui/src/modal/InfoModal.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import AriaModal from 'react-aria-modal'
 
+import { Button } from '../Button'
 import {
   ModalBody,
   ModalContent,
@@ -73,13 +74,12 @@ export class InfoModal extends Component {
             {children}
           </ModalBody>
           <ModalFooter>
-            <button
+            <Button
               id={this.withIdPrefix('close')}
               onClick={onRequestClose}
-              type="button"
             >
               Ok
-            </button>
+            </Button>
           </ModalFooter>
         </ModalContent>
       </AriaModal>

--- a/packages/ui/src/modal/InfoModal.js
+++ b/packages/ui/src/modal/InfoModal.js
@@ -32,10 +32,12 @@ export class InfoModal extends Component {
     children: PropTypes.node,
     onRequestClose: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
+    width: PropTypes.string,
   }
 
   static defaultProps = {
     children: undefined,
+    width: 'auto',
   }
 
   id = getId()
@@ -53,6 +55,7 @@ export class InfoModal extends Component {
 
     return (
       <AriaModal
+        dialogStyle={{ width: this.props.width }}
         getApplicationNode={getApplicationNode}
         initialFocus={`#${this.withIdPrefix('close')}`}
         onExit={onRequestClose}

--- a/packages/ui/src/modal/styles.js
+++ b/packages/ui/src/modal/styles.js
@@ -36,9 +36,15 @@ export const ModalHeaderCloseButton = styled.button`
   background: none;
   border: none;
   color: #0008;
+  cursor: pointer;
+  font-size: 16px;
   margin: -1rem -1rem -1rem auto;
   padding: 1rem;
   -webkit-appearance: none;
+
+  &:focus {
+    color: #000;
+  }
 
   &:hover {
     color: #000;


### PR DESCRIPTION
To promote UI consistency across different parts of the browser. Based on Bootstrap styles since that is what the current browser uses.

Add UI components for:
* Badges
* Buttons (a generic Button vs the current ClassicExacButton)
* Checkboxes
* Links
* Lists
* Page styles (there's some overlap between these and existing components in `genePage/userInterface.js`, but there should be generic components for use in *any* page)

Eventually (if it's desired for other browsers) we can style some of these generic components using [styled-component's theming](https://www.styled-components.com/docs/advanced#theming) vs having different components for different styles (such as the current ClassicExacButton vs MaterialButton). This will make it easier to reuse components across different browsers.

![screen shot 2018-08-30 at 11 15 25 am](https://user-images.githubusercontent.com/1156625/44861264-2bf58900-ac46-11e8-826e-8db866cfdcc6.png)

