### PR TITLE
Configure ESLint to not conflict with Prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,11 @@
 const path = require('path')
 
 module.exports = {
-  extends: 'airbnb',
+  extends: [
+    'airbnb',
+    'prettier',
+    'prettier/react',
+  ],
   env: {
     browser: true,
   },
@@ -10,10 +14,7 @@ module.exports = {
     'prettier',
   ],
   rules: {
-     // Avoid conflict with Prettier
-    'arrow-parens': ['error', 'as-needed', { requireForBlockBody: false }],
     'prettier/prettier': 'error',
-    'semi': [2, 'never'],
     'no-shadow': 0,
     'no-console': 0,
     'func-names': 0,
@@ -23,8 +24,6 @@ module.exports = {
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
     'jsx-a11y/href-no-hash': 0,
     'import/no-mutable-exports': 0,
-    'no-confusing-arrow': 0,
-    'space-before-function-paren': 0,
     'no-use-before-define': 0,
     'no-unused-vars': ['error', {
       ignoreRestSiblings: true,
@@ -33,13 +32,6 @@ module.exports = {
     'import/prefer-default-export': 0,
     // 'import/no-extraneous-dependencies': ['error', {'devDependencies': ['**/*.test.js', '**/*.spec.js', '**/*.example.js']}],
     'import/no-extraneous-dependencies': 0,
-    'comma-dangle': ['error', {
-      arrays: 'only-multiline',
-      objects: 'only-multiline',
-      imports: 'only-multiline',
-      exports: 'only-multiline',
-      functions: 'never',
-    }],
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "elasticsearch": "^13.3.1",
     "eslint": "^4.6.1",
     "eslint-config-airbnb": "^15.1.0",
+    "eslint-config-prettier": "^3.0.1",
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-graphql": "^1.4.1",
     "eslint-plugin-import": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3660,6 +3660,12 @@ eslint-config-airbnb@^15.1.0:
   dependencies:
     eslint-config-airbnb-base "^11.3.0"
 
+eslint-config-prettier@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.0.1.tgz#479214f64c1a4b344040924bfb97543db334b7b1"
+  dependencies:
+    get-stdin "^6.0.0"
+
 eslint-import-resolver-node@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz#4422574cde66a9a7b099938ee4d508a199e0e3cc"
@@ -4496,6 +4502,10 @@ get-stdin@^4.0.1:
 get-stdin@^5.0.0, get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
 
 get-stream@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Some of the rules in AirBnB's ESLint configuration conflict with Prettier. This disables any rules which may cause warnings/errors on code formatted with Prettier.