### PR TITLE
Present empty cells as blank rather than "null" in tables

### DIFF
--- a/packages/table/src/Table.js
+++ b/packages/table/src/Table.js
@@ -307,7 +307,7 @@ const getDataCell = (field, dataRow, searchText, i, onRowClick) => {
   const cellText = field.searchable ? (
     <Highlighter
       searchWords={searchText.split(/\s+/)}
-      textToHighlight={`${dataRow[dataKey]}`}
+      textToHighlight={`${dataRow[dataKey] || ''}`}
     />
   ) : dataRow[dataKey]
 


### PR DESCRIPTION
This is intended to prevent "null" being displayed in (e.g.) the HGVSc column of our Variant table.

Very open to suggestions for a cleaner and/or more appropriate solution!