### PR TITLE
Update API Docker build/deployment

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,16 +1,10 @@
-FROM node:5.10.0
+FROM node:7.5.0
 
-MAINTAINER Matthew Solomonson
+LABEL maintainer="MacArthur Lab"
 
-ENV NODE_ENV=production PORT=9000 MONGO_URL=mongodb://localhost:27017/exac
-
-COPY . /var/www
 WORKDIR /var/www
+COPY package.json /var/www/
+RUN npm install --production
+COPY build /var/www/build
 
-RUN npm install --dev \
-    && npm run build
-
-EXPOSE 80
-
-ENTRYPOINT ["npm"]
-CMD ["run", "prod"]
+CMD ["node", "build/server.js"]

--- a/packages/api/deploy/Makefile
+++ b/packages/api/deploy/Makefile
@@ -4,18 +4,6 @@ include ../../../cluster/config.sh
 POOL_NAME=redis
 PROJECT_NAME=gnomad-api
 
-BASE_IMAGE_PREFIX=gcr.io/$(GCLOUD_PROJECT)/$(PROJECT_NAME)-base
-IMAGE_PREFIX=gcr.io/$(GCLOUD_PROJECT)/$(PROJECT_NAME)
-VERSION=0
-BUILD_TIME=$(shell date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s")
-# IMAGE_TAG=:$(BUILD_TIME)
-IMAGE_TAG=
-SOURCE_DIRECTORY=..
-API_EXTERNAL_IP=35.184.79.173
-
-BASE_IMAGE_NAME="$(BASE_IMAGE_PREFIX)$(IMAGE_TAG)"
-MAIN_IMAGE_NAME="$(IMAGE_PREFIX)$(IMAGE_TAG)"
-
 SERVICE_FORWARDING_RULE_ID=$(shell gcloud compute forwarding-rules list --format='value[terminator=" "](name)' --filter=35.184.79.173)
 
 start-api: mongo-legacy gnomad-api gnomad-api-service
@@ -27,19 +15,6 @@ mongo-legacy:
 	@-kubectl create -f gnomad-mongo-controller.yaml
 	@-kubectl create -f gnomad-mongo-service.yaml
 
-build-base:
-	docker build -f dockerfiles/gnomadgraphqlbase.dockerfile \
-		-t $(BASE_IMAGE_NAME) $(SOURCE_DIRECTORY)
-	gcloud docker -- push $(BASE_IMAGE_NAME)
-
-build-main:
-	npm run build
-	docker build -f dockerfiles/gnomadgraphql.dockerfile \
-		-t $(MAIN_IMAGE_NAME) $(SOURCE_DIRECTORY)
-	gcloud docker -- push $(MAIN_IMAGE_NAME)
-
-build-all: build-base build-main
-
 gnomad-api:
 	@-kubectl create -f gnomad-api-controller.yaml
 
@@ -50,11 +25,6 @@ gnomad-api:
 gnomad-api-service:
 	@-kubectl expose deployment $(PROJECT_NAME) \
 	--type="LoadBalancer"
-
-update-gnomad-api:
-	# $(sed -ie "s/THIS_STRING_IS_REPLACED_DURING_BUILD/$(BUILD_TIME)/g" gnomad-api-controller.yml)
-	kubectl delete -f gnomad-api-controller.yaml
-	kubectl create -f gnomad-api-controller.yaml
 
 set-max-result:
 	curl -XPUT "http://elastic:9200/*/_settings" -d '{ "index" : { "max_result_window" : 500000 } }'
@@ -97,9 +67,6 @@ redis-flush-local:
 
 redis-dump-size:
 	kubectl exec -it redis-master -- ls -al --block-size=M /redis-master-data
-
-update: build-main update-gnomad-api
-	kubectl get pods
 
 dev:
 	redis-cli flushall

--- a/packages/api/deploy/README.md
+++ b/packages/api/deploy/README.md
@@ -1,0 +1,38 @@
+# API Deployment
+
+## Build image
+
+To build a Docker image containing the API server and its dependencies:
+
+```shell
+cd gnomadjs/packages/api
+./deploy/build-image.sh
+```
+
+This will create an image named "gnomad-api" tagged with the hash of the current git revision.
+
+## Deploy image to Kubernetes
+
+After an image has been built, deploy it to Kubernetes with:
+
+```shell
+cd gnomadjs/packages/api
+./deploy/deploy-image.sh tag
+```
+
+where `tag` is the tag on the "gnomad-api" image to be deployed.
+
+## Run image locally
+
+To run the API server in Docker on macOS using a local instance of Mongo and Redis:
+
+```shell
+docker run --rm -ti --init \
+   -p 8007:80 \
+   -e "GRAPHQL_PORT=80" \
+   -e "NODE_ENV=development" \
+   -e "ELASTICSEARCH_URL=elastic:9200" \
+   -e "GNOMAD_MONGO_URL=mongodb://host.docker.internal:27017/exac" \
+   -e "REDIS_HOST=host.docker.internal" \
+   gcr.io/exac-gnomad/gnomad-api
+```

--- a/packages/api/deploy/build-image.sh
+++ b/packages/api/deploy/build-image.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+# cd to packages/api directory
+DEPLOY_DIR=$(dirname "${BASH_SOURCE}")
+cd "${DEPLOY_DIR}/.."
+
+source "../../cluster/config.sh"
+IMAGE_NAME="gcr.io/${GCLOUD_PROJECT}/gnomad-api"
+
+# Compile JS
+yarn run build
+
+# Tag image with git revision
+# Add "-modified" if there are uncommitted local changes
+COMMIT_HASH=$(git rev-parse --short HEAD)
+GIT_STATUS=$(git status --porcelain 2> /dev/null | tail -n1)
+IMAGE_TAG=${COMMIT_HASH}
+if [[ -n $GIT_STATUS ]]; then
+  IMAGE_TAG=${IMAGE_TAG}-modified
+fi
+
+docker build --tag ${IMAGE_NAME}:${IMAGE_TAG} --tag ${IMAGE_NAME}:latest .
+
+echo ${IMAGE_NAME}:${IMAGE_TAG}

--- a/packages/api/deploy/deploy-image.sh
+++ b/packages/api/deploy/deploy-image.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: deploy-image.sh tag" 1>&2
+  exit 1
+fi
+
+DEPLOY_TAG=$1
+
+# cd to packages/api directory
+DEPLOY_DIR=$(dirname "${BASH_SOURCE}")
+cd "${DEPLOY_DIR}/.."
+
+source "../../cluster/config.sh"
+IMAGE_NAME="gcr.io/${GCLOUD_PROJECT}/gnomad-api"
+
+# Push to container registry
+gcloud docker -- push ${IMAGE_NAME}/${DEPLOY_TAG}
+
+# Update API deployment
+kubectl set image deployment/gnomad-api gnomad-api-pod=${IMAGE_NAME}/${DEPLOY_TAG}
+
+# Wait for rollout to finish
+kubectl rollout status deployment/gnomad-api

--- a/packages/api/deploy/dockerfiles/gnomadgraphql.dockerfile
+++ b/packages/api/deploy/dockerfiles/gnomadgraphql.dockerfile
@@ -1,7 +1,0 @@
-FROM gcr.io/exac-gnomad/gnomad-api-base
-
-MAINTAINER MacArthur Lab
-
-COPY build /var/www/build
-
-CMD ["node", "build/server.js"]

--- a/packages/api/deploy/dockerfiles/gnomadgraphqlbase.dockerfile
+++ b/packages/api/deploy/dockerfiles/gnomadgraphqlbase.dockerfile
@@ -1,9 +1,0 @@
-FROM node:7.5.0
-
-MAINTAINER MacArthur Lab
-
-WORKDIR /var/www
-
-COPY package.json /var/www/
-
-RUN npm install --production


### PR DESCRIPTION
* Combine API Dockerfiles
Previously, the deployed image was built from `api/deploy/dockerfiles/gnomadgraphqlbase.dockerfile` and `api/deploy/dockerfiles/gnomadgraphql.dockerfile` and `api/Dockerfile` was unused. It seems the motivation for using two Dockerfiles was to avoid reinstalling node modules when rebuilding an image after changing API code. Using two images required us to remember to rebuild `gnomad-api-base` when dependencies changed. Using one Dockerfile, they will automatically be installed if package.json changes and Docker's build cache will prevent reinstalling them if package.json is unchanged.

* Tag images with git revision
Previously, when deploying an update, we pushed an untagged image and then deleted and recreated the K8S deployment to so that the latest image would be used. With tagged images, we can use K8S rolling updates to prevent downtime during deployments. Tagging with the git revision also makes it easy to see exactly what code is currently deployed.