### PR TITLE
Restyle consequence category filter

### DIFF
--- a/packages/dev-server/public/index.html
+++ b/packages/dev-server/public/index.html
@@ -6,9 +6,9 @@
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
     <link type="image/x-icon" rel="shortcut icon" />
 
-    <!-- <link href='http://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'> -->
-    <link href="https://fonts.googleapis.com/css?family=Julius+Sans+One|Pacifico" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Pacifico" rel="stylesheet">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,700">
+
     <!-- use the font -->
     <style>
       body {

--- a/packages/redux-genes/src/GenePageHoc.js
+++ b/packages/redux-genes/src/GenePageHoc.js
@@ -112,36 +112,27 @@ const GenePageContainer = ComposedComponent => class GenePage extends Component 
 
 const mapDispatchToProps = geneFetchFunction => dispatch => ({
   fetchGeneData(geneName, transcriptId) {
-    return dispatch((thunkDispatch) => {
+    return dispatch(thunkDispatch => {
       thunkDispatch(geneActions.setCurrentGene(geneName))
       thunkDispatch(geneActions.setCurrentTranscript(transcriptId))
 
       thunkDispatch(geneActions.requestGeneData(geneName))
-      return geneFetchFunction(geneName, transcriptId)
-        .then((geneData) => {
-          thunkDispatch(geneActions.receiveGeneData(geneName, geneData))
+      return geneFetchFunction(geneName, transcriptId).then(geneData => {
+        thunkDispatch(geneActions.receiveGeneData(geneName, geneData))
 
-          // Reset variant filters when loading a new gene
-          thunkDispatch(variantActions.searchVariants(''))
+        // Reset variant filters when loading a new gene
+        thunkDispatch(variantActions.searchVariants(''))
+        thunkDispatch(
+          variantActions.setVariantFilter({
+            lof: true,
+            missense: true,
+            synonymous: true,
+            other: true,
+          })
+        )
 
-          let defaultVariantFilter = 'all'
-          if (geneData) {
-            const exons = geneData.transcript.exons
-            const padding = 75
-            const totalBasePairs = exons.filter(region => region.feature_type === 'CDS')
-              .reduce((acc, { start, stop }) => (acc + ((stop - start) + (padding * 2))), 0)
-
-            if (totalBasePairs > 100000) {
-              defaultVariantFilter = 'lof'
-            } else if (totalBasePairs > 40000) {
-              defaultVariantFilter = 'missenseOrLoF'
-            }
-          }
-
-          thunkDispatch(variantActions.setVariantFilter(defaultVariantFilter))
-
-          return geneData
-        })
+        return geneData
+      })
     })
   },
 })

--- a/packages/region/src/RegionHoc.js
+++ b/packages/region/src/RegionHoc.js
@@ -99,9 +99,20 @@ export const RegionHoc = (
           .then((regionData) => {
             thunkDispatch(regionActions.receiveRegionData(regionId, regionData))
 
-            const defaultVariantFilter = (regionData.stop - regionData.start) > 50000
-              ? 'lof'
-              : 'all'
+            let defaultVariantFilter = {
+              lof: true,
+              missense: true,
+              synonymous: true,
+              other: true,
+            }
+            if (regionData.stop - regionData.start > 50000) {
+              defaultVariantFilter = {
+                lof: true,
+                missense: false,
+                synonymous: false,
+                other: false,
+              }
+            }
 
             // Reset variant filters when loading a new region
             thunkDispatch(variantActions.searchVariants(''))

--- a/packages/ui/src/ConsequenceCategoriesControl.js
+++ b/packages/ui/src/ConsequenceCategoriesControl.js
@@ -1,0 +1,131 @@
+import { hideVisually, transparentize } from 'polished'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import styled from 'styled-components'
+
+const categories = ['lof', 'missense', 'synonymous', 'other']
+
+const categoryColors = {
+  lof: '#FF583F',
+  missense: '#F0C94D',
+  synonymous: 'green',
+  other: '#757575',
+}
+
+const categoryLabels = {
+  lof: 'LoF',
+  missense: 'Missense',
+  synonymous: 'Synonymous',
+  other: 'Other',
+}
+
+const Checkbox = styled.input.attrs({ type: 'checkbox' })`
+  ${hideVisually()};
+`
+
+const CheckboxIcon = styled.span`
+  position: relative;
+  top: 1px;
+  left: 1px;
+  width: 1em;
+  padding: 0.375em 0.5em;
+`
+
+const Label = styled.label`
+  display: inline-flex;
+  overflow: hidden;
+  border-color: ${props => props.borderColor};
+  border-style: solid;
+  border-width: 1px;
+  background: ${props =>
+    `linear-gradient(to right, ${props.backgroundColor}, ${
+      props.backgroundColor
+    } 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0))`};
+  cursor: pointer;
+  user-select: none;
+
+  &:focus-within {
+    box-shadow: ${props => `0 0 0 0.2em ${transparentize(0.5, props.borderColor)}`};
+  }
+
+  &:first-child {
+    border-top-left-radius: 0.5em;
+    border-bottom-left-radius: 0.5em;
+  }
+
+  &:last-child {
+    border-top-right-radius: 0.5em;
+    border-bottom-right-radius: 0.5em;
+  }
+`
+
+const LabelText = styled.span`
+  padding: 0.375em 0.75em;
+`
+
+const KEYBOARD_SHORTCUTS = {
+  l: 'lof',
+  m: 'missense',
+  s: 'synonymous',
+  o: 'other',
+}
+
+export class ConsequenceCategoriesControl extends Component {
+  componentDidMount() {
+    document.addEventListener('keypress', this.onKeyPress)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keypress', this.onKeyPress)
+  }
+
+  onKeyPress = e => {
+    const key = e.key.toLowerCase()
+    if (key in KEYBOARD_SHORTCUTS) {
+      const toggledCategory = KEYBOARD_SHORTCUTS[key]
+      const { categorySelections, onChange } = this.props
+
+      onChange({ ...categorySelections, [toggledCategory]: !categorySelections[toggledCategory] })
+    }
+  }
+
+  render() {
+    const { categorySelections, id, onChange } = this.props
+
+    return (
+      <div>
+        {categories.map(category => (
+          <Label
+            key={category}
+            backgroundColor={transparentize(0.5, categoryColors[category])}
+            borderColor={categoryColors[category]}
+            htmlFor={`${id}-${category}`}
+          >
+            <Checkbox
+              checked={categorySelections[category]}
+              id={`${id}-${category}`}
+              type="checkbox"
+              onChange={e => onChange({ ...categorySelections, [category]: e.target.checked })}
+            />
+            <CheckboxIcon
+              aria-hidden
+              className={`fa ${categorySelections[category] ? 'fa-check-square-o' : 'fa-square-o'}`}
+            />
+            <LabelText>{categoryLabels[category]}</LabelText>
+          </Label>
+        ))}
+      </div>
+    )
+  }
+}
+
+ConsequenceCategoriesControl.propTypes = {
+  categorySelections: PropTypes.shape({
+    lof: PropTypes.bool.isRequired,
+    missense: PropTypes.bool.isRequired,
+    synonymous: PropTypes.bool.isRequired,
+    other: PropTypes.bool.isRequired,
+  }).isRequired,
+  id: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+}

--- a/packages/ui/src/classicExac/button.js
+++ b/packages/ui/src/classicExac/button.js
@@ -26,23 +26,3 @@ export const ClassicExacButton = styled.button`
     disabled ? '#FAFAFA' : 'white'
   )};
 `
-
-export const ClassicExacButtonFirst = ClassicExacButton.extend`
-  border-bottom-left-radius: 4px;
-  border-top-left-radius: 4px;
-  ${'' /* border-right-width: 1.5px; */}
-  ${'' /* border-right-color: rgb(40, 94, 142); */}
-  border-right-style: solid;
-`
-
-export const ClassicExacButtonLast = ClassicExacButton.extend`
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
-  ${'' /* border-left-width: 1.5px; */}
-  ${'' /* border-left-color: rgb(40, 94, 142); */}
-`
-
-export const ClassicExacButtonGroup = styled.div`
-  display: flex;
-  flex-direction: row;
-`

--- a/packages/ui/src/example/ConsequenceCategoriesControlExample.js
+++ b/packages/ui/src/example/ConsequenceCategoriesControlExample.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react'
+
+import { ConsequenceCategoriesControl } from '..'
+
+export default class ConsequenceCategoriesControlExample extends Component {
+  state = {
+    categorySelections: {
+      lof: false,
+      missense: false,
+      synonymous: false,
+      other: false,
+    },
+  }
+
+  onChange = categorySelections => {
+    this.setState({ categorySelections })
+  }
+
+  render() {
+    return (
+      <ConsequenceCategoriesControl
+        id="consequence-categories-control-example"
+        categorySelections={this.state.categorySelections}
+        onChange={this.onChange}
+      />
+    )
+  }
+}

--- a/packages/ui/src/example/index.js
+++ b/packages/ui/src/example/index.js
@@ -14,6 +14,7 @@ import {
   TextButton,
 } from '..'
 import CheckboxExample from './CheckboxExample'
+import ConsequenceCategoriesControlExample from './ConsequenceCategoriesControlExample'
 import InfoModalExample from './InfoModalExample'
 import SegmentedControlExample from './SegmentedControlExample'
 import TooltipExample from './TooltipExample'
@@ -49,6 +50,11 @@ const UiExample = () => (
     <Section>
       <SectionHeading>Checkbox</SectionHeading>
       <CheckboxExample />
+    </Section>
+
+    <Section>
+      <SectionHeading>Consequence Category Filter</SectionHeading>
+      <ConsequenceCategoriesControlExample />
     </Section>
 
     <Section>

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -4,15 +4,12 @@ export {
 
 export { BaseButton, Button, PrimaryButton, TextButton } from './Button'
 
-export {
-  ClassicExacButton,
-  ClassicExacButtonFirst,
-  ClassicExacButtonLast,
-  ClassicExacButtonGroup,
-} from './classicExac/button'
+export { ClassicExacButton } from './classicExac/button'
+
+export { ConsequenceCategoriesControl } from './ConsequenceCategoriesControl'
 
 export {
-  Search,
+  Search
 } from './search/simpleSearch'
 
 export {

--- a/packages/utilities/src/index.js
+++ b/packages/utilities/src/index.js
@@ -22,6 +22,7 @@ export {
 } from './exalt'
 
 export {
+  getCategoryFromConsequence,
   isCategoryLoF,
   isCategoryMissenseOrLoF,
 } from './constants/categoryDefinitions'

--- a/projects/gnomad/src/GenePage/RegionViewer.js
+++ b/projects/gnomad/src/GenePage/RegionViewer.js
@@ -21,7 +21,6 @@ import {
 import {
   finalFilteredVariants,
   selectedVariantDataset,
-  variantFilter,
 } from '@broad/redux-variants'
 
 import {
@@ -90,7 +89,6 @@ const GeneViewer = ({
   exonPadding,
   regionalConstraint,
   screenSize,
-  variantFilter,
 }) => {
   const smallScreen = screenSize.width < 900
   const regionViewerWidth = smallScreen ? screenSize.width - 150 : screenSize.width - 330
@@ -126,12 +124,6 @@ const GeneViewer = ({
     gnomadGenomeVariants: 'gnomAD genomes',
     gnomadCombinedVariants: 'gnomAD',
     exacVariants: 'ExAC',
-  }
-  const consequenceTranslations = {
-    all: 'All variants',
-    gnomadGenomeVariants: 'gnomAD genomes',
-    missenseOrLoF: 'Missense/LoF',
-    lof: 'LoF',
   }
 
   return (
@@ -172,7 +164,7 @@ const GeneViewer = ({
           />}
 
         <VariantAlleleFrequencyTrack
-          title={`${datasetTranslations[selectedVariantDataset]}\n${consequenceTranslations[variantFilter]}\n(${allVariants.size})`}
+          title={`${datasetTranslations[selectedVariantDataset]}\n(${allVariants.size})`}
           variants={variantsReversed.toJS()}
         />
         <NavigatorTrackConnected title={'Viewing in table'} />
@@ -185,7 +177,6 @@ GeneViewer.propTypes = {
   allVariants: PropTypes.any.isRequired,
   exonPadding: PropTypes.number.isRequired,
   selectedVariantDataset: PropTypes.string.isRequired,
-  variantFilter: PropTypes.string.isRequired,
   regionalConstraint: PropTypes.array.isRequired,
   screenSize: PropTypes.object.isRequired,
 }
@@ -197,6 +188,5 @@ export default connect(
     selectedVariantDataset: selectedVariantDataset(state),
     regionalConstraint: regionalConstraint(state),
     screenSize: screenSize(state),
-    variantFilter: variantFilter(state),
   })
 )(GeneViewer)

--- a/projects/gnomad/src/RegionPage/RegionViewer.js
+++ b/projects/gnomad/src/RegionPage/RegionViewer.js
@@ -16,7 +16,6 @@ import { NavigatorTrackConnected } from '@broad/track-navigator'
 import {
   finalFilteredVariants,
   selectedVariantDataset,
-  variantFilter,
 } from '@broad/redux-variants'
 
 import { getCoverageConfig } from '../GenePage/RegionViewer'
@@ -27,7 +26,6 @@ const RegionViewerConnected = ({
   history,
   selectedVariantDataset,
   screenSize,
-  variantFilter,
 }) => {
   const {
     chrom,
@@ -73,12 +71,6 @@ const RegionViewerConnected = ({
     gnomadCombinedVariants: 'gnomAD',
     exacVariants: 'ExAC',
   }
-  const consequenceTranslations = {
-    all: 'All variants',
-    gnomadGenomeVariants: 'gnomAD genomes',
-    missenseOrLoF: 'Missense/LoF',
-    lof: 'LoF',
-  }
 
   return (
     <div>
@@ -105,7 +97,7 @@ const RegionViewerConnected = ({
         />
 
         <VariantAlleleFrequencyTrack
-          title={`${datasetTranslations[selectedVariantDataset]}\n${consequenceTranslations[variantFilter]}\n(${allVariants.size})`}
+          title={`${datasetTranslations[selectedVariantDataset]}\n(${allVariants.size})`}
           variants={variantsReversed.toJS()}
         />
 
@@ -137,7 +129,6 @@ export default compose(
       allVariants: finalFilteredVariants(state),
       selectedVariantDataset: selectedVariantDataset(state),
       screenSize: screenSize(state),
-      variantFilter: variantFilter(state),
     })
   )
 )(RegionViewerConnected)

--- a/projects/gnomad/src/Settings.js
+++ b/projects/gnomad/src/Settings.js
@@ -22,7 +22,6 @@ import {
   Search,
 } from '@broad/ui'
 
-
 const GeneSettings = ({
   selectedVariantDataset,
   searchVariants,
@@ -31,72 +30,106 @@ const GeneSettings = ({
   setSelectedVariantDataset,
   toggleVariantQcFilter,
   variantQcFilter,
-}) => {
-  return (
-    <SettingsContainer>
-      <MenusContainer>
-        <DataSelectionGroup>
-          <ClassicExacButtonGroup>
-            <ClassicExacButtonFirst
-              isActive={variantFilter === 'all'}
-              onClick={() => setVariantFilter('all')}
-            >
-              All
-            </ClassicExacButtonFirst>
-            <ClassicExacButton
-              isActive={variantFilter === 'missenseOrLoF'}
-              onClick={() => setVariantFilter('missenseOrLoF')}
-            >
-              Missense + LoF
-            </ClassicExacButton>
-            <ClassicExacButtonLast
-              isActive={variantFilter === 'lof'}
-              onClick={() => setVariantFilter('lof')}
-            >
-              LoF
-            </ClassicExacButtonLast>
-          </ClassicExacButtonGroup>
+}) => (
+  <SettingsContainer>
+    <MenusContainer>
+      <DataSelectionGroup>
+        <ClassicExacButtonGroup>
+          <ClassicExacButtonFirst
+            isActive={
+              variantFilter.lof &&
+              variantFilter.missense &&
+              variantFilter.synonymous &&
+              variantFilter.other
+            }
+            onClick={() =>
+              setVariantFilter({
+                lof: true,
+                missense: true,
+                synonymous: true,
+                other: true,
+              })
+            }
+          >
+            All
+          </ClassicExacButtonFirst>
+          <ClassicExacButton
+            isActive={
+              variantFilter.lof &&
+              variantFilter.missense &&
+              !variantFilter.synonymous &&
+              !variantFilter.other
+            }
+            onClick={() =>
+              setVariantFilter({
+                lof: true,
+                missense: true,
+                synonymous: false,
+                other: false,
+              })
+            }
+          >
+            Missense + LoF
+          </ClassicExacButton>
+          <ClassicExacButtonLast
+            isActive={
+              variantFilter.lof &&
+              !variantFilter.missense &&
+              !variantFilter.synonymous &&
+              !variantFilter.other
+            }
+            onClick={() =>
+              setVariantFilter({
+                lof: true,
+                missense: false,
+                synonymous: false,
+                other: false,
+              })
+            }
+          >
+            LoF
+          </ClassicExacButtonLast>
+        </ClassicExacButtonGroup>
 
-          <DataSelectionContainer>
-            <select
-              onChange={event => setSelectedVariantDataset(event.target.value)}
-              value={selectedVariantDataset}
-            >
-              <option value="gnomadExomeVariants">gnomAD exomes</option>
-              <option value="gnomadGenomeVariants">gnomAD genomes</option>
-              <option value="gnomadCombinedVariants">gnomAD</option>
-              <option value="exacVariants">ExAC</option>
-            </select>
-            <QuestionMark topic={'dataset-selection'} display={'inline'} />
-          </DataSelectionContainer>
-        </DataSelectionGroup>
-        <DataSelectionGroup>
-          <span>
-            <label htmlFor="qcFilter">
-              <input
-                id="qcFilter"
-                type="checkbox"
-                checked={!variantQcFilter}
-                style={{ marginRight: '5px' }}
-                onChange={toggleVariantQcFilter}
-              />
-              Include filtered variants
-            </label>
-            <QuestionMark topic={'include-filtered-variants'} display={'inline'} />
-          </span>
-
-          <SearchContainer>
-            <Search
-              placeholder={'Search variant table'}
-              onChange={searchVariants}
-              withKeyboardShortcuts
+        <DataSelectionContainer>
+          <select
+            onChange={event => setSelectedVariantDataset(event.target.value)}
+            value={selectedVariantDataset}
+          >
+            <option value="gnomadExomeVariants">gnomAD exomes</option>
+            <option value="gnomadGenomeVariants">gnomAD genomes</option>
+            <option value="gnomadCombinedVariants">gnomAD</option>
+            <option value="exacVariants">ExAC</option>
+          </select>
+          <QuestionMark topic={'dataset-selection'} display={'inline'} />
+        </DataSelectionContainer>
+      </DataSelectionGroup>
+      <DataSelectionGroup>
+        <span>
+          <label htmlFor="qcFilter">
+            <input
+              id="qcFilter"
+              type="checkbox"
+              checked={!variantQcFilter}
+              style={{ marginRight: '5px' }}
+              onChange={toggleVariantQcFilter}
             />
-          </SearchContainer>
-        </DataSelectionGroup>
-      </MenusContainer>
-    </SettingsContainer>
-  )
-}
+            Include filtered variants
+          </label>
+          <QuestionMark topic={'include-filtered-variants'} display={'inline'} />
+        </span>
+
+        <SearchContainer>
+          <Search
+            placeholder={'Search variant table'}
+            onChange={searchVariants}
+            withKeyboardShortcuts
+          />
+        </SearchContainer>
+      </DataSelectionGroup>
+    </MenusContainer>
+  </SettingsContainer>
+)
 
 GeneSettings.propTypes = {
   searchVariants: PropTypes.func.isRequired,
@@ -104,27 +137,29 @@ GeneSettings.propTypes = {
   setSelectedVariantDataset: PropTypes.func.isRequired,
   setVariantFilter: PropTypes.func.isRequired,
   toggleVariantQcFilter: PropTypes.func.isRequired,
-  variantFilter: PropTypes.string.isRequired,
+  variantFilter: PropTypes.shape({
+    lof: PropTypes.bool.isRequired,
+    missense: PropTypes.bool.isRequired,
+    synonymous: PropTypes.bool.isRequired,
+    other: PropTypes.bool.isRequired,
+  }).isRequired,
   variantQcFilter: PropTypes.bool.isRequired,
 }
 
-const mapStateToProps = (state) => {
-  return {
-    selectedVariantDataset: selectedVariantDataset(state),
-    variantQcFilter: variantQcFilter(state),
-    variantFilter: variantFilter(state),
-  }
-}
-const mapDispatchToProps = (dispatch) => {
-  return {
-    setVariantFilter: filter => dispatch(variantActions.setVariantFilter(filter)),
-    searchVariants: searchText =>
-      dispatch(variantActions.searchVariants(searchText)),
-    setSelectedVariantDataset: dataset =>
-      dispatch(variantActions.setSelectedVariantDataset(dataset)),
-    toggleVariantQcFilter: () =>
-      dispatch(variantActions.toggleVariantQcFilter()),
-  }
-}
+const mapStateToProps = state => ({
+  selectedVariantDataset: selectedVariantDataset(state),
+  variantQcFilter: variantQcFilter(state),
+  variantFilter: variantFilter(state),
+})
 
-export default connect(mapStateToProps, mapDispatchToProps)(GeneSettings)
+const mapDispatchToProps = dispatch => ({
+  setVariantFilter: filter => dispatch(variantActions.setVariantFilter(filter)),
+  searchVariants: searchText => dispatch(variantActions.searchVariants(searchText)),
+  setSelectedVariantDataset: dataset => dispatch(variantActions.setSelectedVariantDataset(dataset)),
+  toggleVariantQcFilter: () => dispatch(variantActions.toggleVariantQcFilter()),
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(GeneSettings)

--- a/projects/gnomad/src/Settings.js
+++ b/projects/gnomad/src/Settings.js
@@ -10,10 +10,7 @@ import {
   variantQcFilter,
 } from '@broad/redux-variants'
 import {
-  ClassicExacButton,
-  ClassicExacButtonFirst,
-  ClassicExacButtonLast,
-  ClassicExacButtonGroup,
+  ConsequenceCategoriesControl,
   SettingsContainer,
   MenusContainer,
   SearchContainer,
@@ -34,62 +31,11 @@ const GeneSettings = ({
   <SettingsContainer>
     <MenusContainer>
       <DataSelectionGroup>
-        <ClassicExacButtonGroup>
-          <ClassicExacButtonFirst
-            isActive={
-              variantFilter.lof &&
-              variantFilter.missense &&
-              variantFilter.synonymous &&
-              variantFilter.other
-            }
-            onClick={() =>
-              setVariantFilter({
-                lof: true,
-                missense: true,
-                synonymous: true,
-                other: true,
-              })
-            }
-          >
-            All
-          </ClassicExacButtonFirst>
-          <ClassicExacButton
-            isActive={
-              variantFilter.lof &&
-              variantFilter.missense &&
-              !variantFilter.synonymous &&
-              !variantFilter.other
-            }
-            onClick={() =>
-              setVariantFilter({
-                lof: true,
-                missense: true,
-                synonymous: false,
-                other: false,
-              })
-            }
-          >
-            Missense + LoF
-          </ClassicExacButton>
-          <ClassicExacButtonLast
-            isActive={
-              variantFilter.lof &&
-              !variantFilter.missense &&
-              !variantFilter.synonymous &&
-              !variantFilter.other
-            }
-            onClick={() =>
-              setVariantFilter({
-                lof: true,
-                missense: false,
-                synonymous: false,
-                other: false,
-              })
-            }
-          >
-            LoF
-          </ClassicExacButtonLast>
-        </ClassicExacButtonGroup>
+        <ConsequenceCategoriesControl
+          categorySelections={variantFilter}
+          id="variant-filter"
+          onChange={setVariantFilter}
+        />
 
         <DataSelectionContainer>
           <select

--- a/projects/schizophrenia/src/ExomePage/GeneSettings.js
+++ b/projects/schizophrenia/src/ExomePage/GeneSettings.js
@@ -21,68 +21,98 @@ import {
   DataSelectionGroup,
 } from '@broad/ui'
 
+const VariantCategoryButtonGroup = styled.div`
+  display: flex;
+  flex-direction: row;
+`
+
+const VariantCategoryButton = MaterialButtonRaised.extend`
+  margin-right: 10px;
+  background-color: ${({ isActive }) =>
+    isActive ? 'rgba(10, 121, 191, 0.3)' : 'rgba(10, 121, 191, 0.1)'};
+
+  &:hover {
+    background-color: rgba(10, 121, 191, 0.3);
+  }
+
+  &:active {
+    background-color: rgba(10, 121, 191, 0.5);
+  }
+`
+
 const GeneSettings = ({
   searchVariants,
   setVariantFilter,
   toggleVariantDeNovoFilter,
   variantDeNovoFilter,
   variantFilter,
-  // searchVariants
 }) => {
-  const VariantCategoryButtonGroup = styled.div`
-    display: flex;
-    flex-direction: row;
-  `
-
-  const VariantCatagoryButton = MaterialButtonRaised.extend`
-    background-color: ${({ isActive }) => (
-    isActive ? 'rgba(10, 121, 191, 0.3)' : 'rgba(10, 121, 191, 0.1)'
-  )};
-
-    margin-right: 10px;
-    &:hover {
-      background-color: rgba(10, 121, 191, 0.3);
-    }
-    &:active {
-      background-color: rgba(10, 121, 191, 0.5);
-    }
-  `
-
-  const MaterialVariantCategoryButtonGroup = () => (
+  const variantCategoryButtonGroup = (
     <VariantCategoryButtonGroup>
-      <VariantCatagoryButton
-        onClick={() => setVariantFilter('all')}
-        isActive={variantFilter === 'all'}
+      <VariantCategoryButton
+        isActive={
+          variantFilter.lof &&
+          variantFilter.missense &&
+          variantFilter.synonymous &&
+          variantFilter.other
+        }
+        onClick={() =>
+          setVariantFilter({
+            lof: true,
+            missense: true,
+            synonymous: true,
+            other: true,
+          })
+        }
       >
-        All<
-        /VariantCatagoryButton>
-      <VariantCatagoryButton
-        onClick={() => setVariantFilter('missenseOrLoF')}
-        isActive={variantFilter === 'missenseOrLoF'}
+        All
+      </VariantCategoryButton>
+      <VariantCategoryButton
+        isActive={
+          variantFilter.lof &&
+          variantFilter.missense &&
+          !variantFilter.synonymous &&
+          !variantFilter.other
+        }
+        onClick={() =>
+          setVariantFilter({
+            lof: true,
+            missense: true,
+            synonymous: false,
+            other: false,
+          })
+        }
       >
         Missense + LoF
-      </VariantCatagoryButton>
-      <VariantCatagoryButton
-        onClick={() => setVariantFilter('lof')}
-        isActive={variantFilter === 'lof'}
+      </VariantCategoryButton>
+      <VariantCategoryButton
+        isActive={
+          variantFilter.lof &&
+          !variantFilter.missense &&
+          !variantFilter.synonymous &&
+          !variantFilter.other
+        }
+        onClick={() =>
+          setVariantFilter({
+            lof: true,
+            missense: false,
+            synonymous: false,
+            other: false,
+          })
+        }
       >
         LoF
-      </VariantCatagoryButton>
-      <VariantCatagoryButton
-        onClick={toggleVariantDeNovoFilter}
-        isActive={variantDeNovoFilter}
-      >
+      </VariantCategoryButton>
+      <VariantCategoryButton isActive={variantDeNovoFilter} onClick={toggleVariantDeNovoFilter}>
         De novo
-      </VariantCatagoryButton>
+      </VariantCategoryButton>
     </VariantCategoryButtonGroup>
   )
 
   return (
     <SettingsContainer>
       <MenusContainer>
-        <DataSelectionGroup>
-          <MaterialVariantCategoryButtonGroup />
-        </DataSelectionGroup>
+        <DataSelectionGroup>{variantCategoryButtonGroup}</DataSelectionGroup>
         <DataSelectionGroup>
           <SearchContainer>
             <Search
@@ -101,6 +131,13 @@ GeneSettings.propTypes = {
   searchVariants: PropTypes.func.isRequired,
   setVariantFilter: PropTypes.func.isRequired,
   toggleVariantDeNovoFilter: PropTypes.func.isRequired,
+  variantDeNovoFilter: PropTypes.bool.isRequired,
+  variantFilter: PropTypes.shape({
+    lof: PropTypes.bool.isRequired,
+    missense: PropTypes.bool.isRequired,
+    synonymous: PropTypes.bool.isRequired,
+    other: PropTypes.bool.isRequired,
+  }).isRequired,
 }
 
 const mapStateToProps = (state) => {

--- a/projects/schizophrenia/src/ExomePage/RegionViewer.js
+++ b/projects/schizophrenia/src/ExomePage/RegionViewer.js
@@ -98,12 +98,6 @@ class SchizophreniaGeneViewer extends PureComponent {
       .filter(v => v.ac_ctrl > 0)
       .map(v => v.set('allele_freq', v.af_ctrl))
 
-    const consequenceTranslations = {
-      all: 'All variants',
-      missenseOrLoF: 'Missense/LoF',
-      lof: 'LoF',
-    }
-
     // const casesCount = cases.reduce((acc, v) => acc + v.ac_case, 0)
     // const controlsCount = controls.reduce((acc, v) => acc + v.ac_ctrl, 0)
 
@@ -121,11 +115,11 @@ class SchizophreniaGeneViewer extends PureComponent {
             showRightPanel={!smallScreen}
           />
           <VariantAlleleFrequencyTrack
-            title={`Cases\n${consequenceTranslations[variantFilter]}\n(${cases.size})`}
+            title={`Cases\n(${cases.size})`}
             variants={cases.toJS()}
           />
           <VariantAlleleFrequencyTrack
-            title={`Controls\n${consequenceTranslations[variantFilter]}\n(${controls.size})`}
+            title={`Controls\n(${controls.size})`}
             variants={controls.toJS()}
           />
           <NavigatorTrackConnected title={'Viewing in table'} />
@@ -138,7 +132,12 @@ SchizophreniaGeneViewer.propTypes = {
   gene: PropTypes.object.isRequired,
   visibleVariants: PropTypes.any.isRequired,
   exonPadding: PropTypes.number.isRequired,
-  variantFilter: PropTypes.string.isRequired,
+  variantFilter: PropTypes.shape({
+    lof: PropTypes.bool.isRequired,
+    missense: PropTypes.bool.isRequired,
+    synonymous: PropTypes.bool.isRequired,
+    other: PropTypes.bool.isRequired,
+  }).isRequired,
   screenSize: PropTypes.object.isRequired,
 }
 export default connect(

--- a/projects/variantfx/src/GenePage/GeneSettings.js
+++ b/projects/variantfx/src/GenePage/GeneSettings.js
@@ -29,7 +29,7 @@ const GeneSettings = ({
     flex-direction: row;
   `
 
-  const VariantCatagoryButton = MaterialButtonRaised.extend`
+  const VariantCategoryButton = MaterialButtonRaised.extend`
     background-color: rgba(10, 121, 191, 0.1);
     margin-right: 10px;
     &:hover {
@@ -42,9 +42,42 @@ const GeneSettings = ({
 
   const MaterialVariantCategoryButtonGroup = () => (
     <VariantCategoryButtonGroup>
-      <VariantCatagoryButton onClick={() => setVariantFilter('all')}>All</VariantCatagoryButton>
-      <VariantCatagoryButton onClick={() => setVariantFilter('missenseOrLoF')}>Missense + LoF</VariantCatagoryButton>
-      <VariantCatagoryButton onClick={() => setVariantFilter('lof')}>LoF</VariantCatagoryButton>
+      <VariantCategoryButton
+        onClick={() =>
+          setVariantFilter({
+            lof: true,
+            missense: true,
+            synonymous: true,
+            other: true,
+          })
+        }
+      >
+        All
+      </VariantCategoryButton>
+      <VariantCategoryButton
+        onClick={() =>
+          setVariantFilter({
+            lof: true,
+            missense: true,
+            synonymous: false,
+            other: false,
+          })
+        }
+      >
+        Missense + LoF
+      </VariantCategoryButton>
+      <VariantCategoryButton
+        onClick={() =>
+          setVariantFilter({
+            lof: true,
+            missense: false,
+            synonymous: false,
+            other: false,
+          })
+        }
+      >
+        LoF
+      </VariantCategoryButton>
     </VariantCategoryButtonGroup>
   )
 


### PR DESCRIPTION
Allows toggling all consequence categories individually.

<img width="1491" alt="screen shot 2018-09-05 at 4 05 35 pm" src="https://user-images.githubusercontent.com/1156625/45118184-c01f8e80-b125-11e8-900a-6bba95839b8c.png">

Also adds keyboard shortcuts for toggling categories.

Closes #155.
Closes #161.