### PR TITLE
Update gnomAD browser build/deployment scripts

### DIFF
--- a/projects/gnomad/deploy/Makefile
+++ b/projects/gnomad/deploy/Makefile
@@ -2,25 +2,7 @@
 include ../../../cluster/config.sh
 # include ../../../cluster/Makefile
 
-POOL_NAME=redis
-PROJECT_NAME=gnomad-browser-beta
-
-IMAGE_PREFIX=gcr.io/$(GCLOUD_PROJECT)/$(PROJECT_NAME)
-VERSION=0
-BUILD_TIME=$(shell date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s")
-IMAGE_TAG=
-# IMAGE_TAG=:$(BUILD_TIME)
-SOURCE_DIRECTORY=.
-LEGACY_DIRECTORY=/Users/msolomon/Projects/exacg/exac_gnomad_private
-# GNOMAD_EXTERNAL_IP=104.196.46.19
-# GNOMAD_EXTERNAL_IP=35.202.229.180
-GNOMAD_EXTERNAL=http://35.202.229.180/
-
-IMAGE_NAME="$(IMAGE_PREFIX)$(IMAGE_TAG)"
-
 SERVICE_FORWARDING_RULE_ID=$(shell gcloud compute forwarding-rules list --format='value[terminator=" "](name)' --filter=35.202.229.180)
-
-start-gnomad-prod: build-javascript build-legacy create-gnomad-prod gnomad-prod-service
 
 context:
 	gcloud container clusters get-credentials $(CLUSTER_NAME) --zone=$(GCLOUD_ZONE) --project=$(GCLOUD_PROJECT)
@@ -30,41 +12,14 @@ context:
 	--namespace $(CLUSTER_NAMESPACE)
 	kubectl config use-context gke_$(GCLOUD_PROJECT)_$(GCLOUD_ZONE)_$(CLUSTER_NAME)
 
-build-javascript:
-	npm run build:umd
-
-build-legacy:
-	docker build -f $(LEGACY_DIRECTORY)/deploy/dockerfiles/gnomadserve.dockerfile \
-		-t $(IMAGE_NAME) $(LEGACY_DIRECTORY)
-	gcloud docker -- push $(IMAGE_NAME)
-
 create-gnomad-prod:
 	kubectl create -f gnomad-deployment-prod.yaml
 
 create-gnomad-dev:
 	kubectl create -f gnomad-deployment-dev.yaml
 
-recreate-gnomad-prod:
-	# $(sed -ie "s/THIS_STRING_IS_REPLACED_DURING_BUILD/$(BUILD_TIME)/g" gnomad-api-controller.yml)
-	kubectl delete -f gnomad-deployment-prod.yaml
-	kubectl create -f gnomad-deployment-prod.yaml
-
-recreate-gnomad-dev:
-	kubectl delete -f gnomad-deployment-dev.yaml
-	kubectl create -f gnomad-deployment-dev.yaml
-
 pod-name:
 	kubectl get pods -o jsonpath={.items[*].spec.containers[*].name}
-
-copy-javascript:
-	kubectl cp /Users/msolomon/Projects/exacg/exac_gnomad_private/static/genepage.js gnomad-production-2775023726-02vfk:/var/www/static/
-
-update-gnomad-prod: build-javascript build-legacy recreate-gnomad-prod
-
-update-gnomad-dev: build-javascript build-legacy recreate-gnomad-dev
-
-# faster?
-copy: build-javascript copy-javascript
 
 delete-gcloud-forwarding-rule:
 	gcloud -q compute forwarding-rules delete $(SERVICE_FORWARDING_RULE_ID) --region $(GCLOUD_REGION)
@@ -81,4 +36,3 @@ gnomad-dev-service:
 
 test:
 	../../../node_modules/.bin/babel-node deploy
-	

--- a/projects/gnomad/deploy/README.md
+++ b/projects/gnomad/deploy/README.md
@@ -1,0 +1,37 @@
+# gnomAD Browser Deployment
+
+## Build image
+
+To build a Docker image containing the app server and its dependencies:
+
+```shell
+cd gnomadjs/projects/gnomad
+./deploy/build-image.sh
+```
+
+This will create an image named "gnomad-browser-beta" tagged with the hash of the current git revision.
+
+## Deploy image to Kubernetes
+
+After an image has been built, deploy it to Kubernetes with:
+
+```shell
+cd gnomadjs/projects/gnomad
+./deploy/deploy-image.sh tag environment
+```
+
+where `tag` is the tag on the "gnomad-browser-beta" image to be deployed and `environment` is the
+environment to deploy to ("p" for production or "d" for development).
+
+## Run image locally
+
+To run the browser with Flask's debug server in Docker on macOS using a local instance of Mongo:
+
+```shell
+docker run --rm -ti --init \
+   -p 5000:5000 \
+   -e "MONGO_HOST=host.docker.internal" \
+   -e "MONGO_PORT=27017" \
+   gcr.io/exac-gnomad/gnomad-browser-beta \
+   python exac.py --host=0.0.0.0
+```

--- a/projects/gnomad/deploy/build-image.sh
+++ b/projects/gnomad/deploy/build-image.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -eu
+
+# cd to projects/gnomad directory
+DEPLOY_DIR=$(dirname "${BASH_SOURCE}")
+cd "${DEPLOY_DIR}/.."
+
+source "../../cluster/config.sh"
+IMAGE_NAME="gcr.io/${GCLOUD_PROJECT}/gnomad-browser-beta"
+
+# If GNOMAD_BROWSER_DIR is not net, then assume gnomad_browser is checked out side by side
+# with gnomadjs and get absolute path (required by webpack)
+GNOMAD_BROWSER_DIR="${GNOMAD_BROWSER_DIR:-$(cd ../../../gnomad_browser && pwd)}"
+
+# Compile JS
+yarn run build:umd --output-path="${GNOMAD_BROWSER_DIR}/static"
+
+# Tag image with git revision
+# Add "-modified" if there are uncommitted local changes
+COMMIT_HASH=$(git rev-parse --short HEAD)
+GIT_STATUS=$(git status --porcelain 2> /dev/null | tail -n1)
+IMAGE_TAG=${COMMIT_HASH}
+if [[ -n $GIT_STATUS ]]; then
+  IMAGE_TAG=${IMAGE_TAG}-modified
+fi
+
+# Must have new_gene_page branch checked out in gnomad_browser
+pushd $GNOMAD_BROWSER_DIR
+CURRENT_GNOMAD_BROWSER_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ $CURRENT_GNOMAD_BROWSER_BRANCH != "new_gene_page" ]]; then
+  echo "Error: new_gene_page branch must be checked out in gnomad_browser" 1>&2
+  exit 1
+fi
+popd # Back to gnomadjs/projects/gnomad
+
+docker build --file "${GNOMAD_BROWSER_DIR}/deploy/dockerfiles/gnomadserve.dockerfile" \
+  --tag ${IMAGE_NAME}:${IMAGE_TAG} \
+  --tag ${IMAGE_NAME}:latest \
+  ${GNOMAD_BROWSER_DIR}
+
+echo ${IMAGE_NAME}:${IMAGE_TAG}

--- a/projects/gnomad/deploy/deploy-image.sh
+++ b/projects/gnomad/deploy/deploy-image.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -eu
+
+if [ $# -lt 2 ]; then
+  echo "Usage: deploy-image.sh tag p|d" 1>&2
+  exit 1
+fi
+
+DEPLOY_TAG=$1
+ENVIRONMENT=$2
+
+if [[ $ENVIRONMENT != "p" ]] && [[ $ENVIRONMENT != "d" ]]; then
+  echo "Environment must be either 'p' or 'd'" 1>&2
+  exit 1
+fi
+
+# cd to projects/gnomad directory
+DEPLOY_DIR=$(dirname "${BASH_SOURCE}")
+cd "${DEPLOY_DIR}/.."
+
+source "../../cluster/config.sh"
+IMAGE_NAME="gcr.io/${GCLOUD_PROJECT}/gnomad-browser-beta"
+
+# Push to container registry
+gcloud docker -- push ${IMAGE_NAME}/${DEPLOY_TAG}
+
+DEPLOYMENT="gnomad-${ENVIRONMENT}-serve"
+CONTAINER="gnomad-${ENVIRONMENT}-serve"
+
+# Update deployment
+kubectl set image "deployment/${DEPLOYMENT}" "${CONTAINER}=${IMAGE_NAME}/${DEPLOY_TAG}"
+
+# Wait for rollout to finish
+kubectl rollout status "deployment/${DEPLOYMENT}"

--- a/projects/gnomad/webpack.config.umd.js
+++ b/projects/gnomad/webpack.config.umd.js
@@ -1,16 +1,16 @@
 const path = require('path')
 
 const webpack = require('webpack')
+
 const config = require('../../webpack.config')
 
 const umdConfig = {
   devtool: 'source-map',
   entry: {
-    genepage: ['babel-polyfill', './src/index.umd.js']
+    genepage: ['babel-polyfill', './src/index.umd.js'],
   },
   output: {
-    path: '/Users/msolomon/Projects/exacg/exac_gnomad_private/static',
-    // path: path.resolve(__dirname, 'dist/umd'),
+    path: path.resolve(__dirname, 'dist/umd'),
     filename: '[name]-1517593459.js',
     libraryTarget: 'umd',
     library: 'ReactGnomad',


### PR DESCRIPTION
#209 for the browser image

* Tag Docker images with the git revision so that we can use rolling updates for deployments and specify different images for development and production environments.
* Remove copy tasks from Makefile. Updating the browser by copying JS files to a running container isn't a good practice since the pod may be deleted and recreated at any time, which would revert the browser to the latest Docker image.
* Remove hard coded paths from build script and webpack config. `build-image.sh` will assume that gnomad_browser is checked out side by side with gnomadjs. This can be overridden by setting the `GNOMAD_BROWSER_DIR` environment variable (ex. `GNOMAD_BROWSER_DIR=~/path/to/gnomad_browser ./build-image.sh`)
* Documentation for deployment and running the browser image locally.