### PR TITLE
Appropriately filter variants that have multiple consequences

### DIFF
--- a/packages/utilities/src/constants/categoryDefinitions.js
+++ b/packages/utilities/src/constants/categoryDefinitions.js
@@ -77,13 +77,13 @@ export function getCategoryFromConsequence(consequence) {
 }
 
 export function isCategoryLoF(consequence) {
-  return CATEGORY_DEFINITIONS_MAP.get('lof').contains(consequence)
+  return consequence.split('&').some(csq => CATEGORY_DEFINITIONS_MAP.get('lof').contains(csq))
 }
 export function isCategoryMissense(consequence) {
-  return CATEGORY_DEFINITIONS_MAP.get('missense').contains(consequence)
+  return consequence.split('&').some(csq => CATEGORY_DEFINITIONS_MAP.get('missense').contains(csq))
 }
 export function isCategoryMissenseOrLoF(consequence) {
-  return CATEGORY_DEFINITIONS_MAP.get('missenseAndLof').contains(consequence)
+  return consequence.split('&').some(consequence => CATEGORY_DEFINITIONS_MAP.get('missenseAndLof').contains(csq))
 }
 
 


### PR DESCRIPTION
I am _not_ suggesting that this is merged as-is. This is instead a request for comments.

In response to previous feedback from @nickywhiff I changed the category definitions such that variants with `Consequence` fields of the form `stop_gained&frameshift_variant` (e.g. 11-47364656-T-TATCA) would be classified as `lof`. Previously this would only occur if `Consequence` was either `stop_gained` or `frameshift_variant`.

I am not sure whether this is either a) logically sensible and b) if so, how we isolate this change to VariantFX (we previously talked about passing a function). Any suggestions very welcome!