### PR TITLE
Make variant consequence filter configurable

### DIFF
--- a/projects/variantfx/src/Main.js
+++ b/projects/variantfx/src/Main.js
@@ -2,11 +2,24 @@ import React from 'react'
 import { BrowserRouter as Router, Route } from 'react-router-dom'
 import { Provider } from 'react-redux'
 import createGenePageStore from '@broad/gene-page/src/store/store'
+import { getCategoryFromConsequence } from '@broad/utilities'
 import { actions as userInterfaceActions } from '@broad/ui'
 import { variantfx } from './redux'
 import App from './routes'
 
 const appSettings = {
+  variantMatchesConsequenceCategoryFilter(variant, selectedCategories) {
+    const consequences = variant.Consequence.split('&')
+    const categories = consequences.map(consequence => {
+      let category = getCategoryFromConsequence(consequence) || 'other'
+      if (category === 'all') {
+        category = 'other'
+      }
+      return category
+    })
+
+    return categories.some(category => selectedCategories[category])
+  },
   variantSearchPredicate(variant, query) {
     return (
       variant.get('variant_id').toLowerCase().includes(query)
@@ -24,9 +37,6 @@ const appSettings = {
     startingVariant: '14-23902914-C-G',
     startingPadding: 75,
     startingVariantDataset: 'variants',
-  },
-  definitions: {
-    consequence: 'Consequence',
   },
   variantDatasets: {
     variants: {


### PR DESCRIPTION
VariantFX's variant data is in a slightly different format from gnomAD's. The field name for consequence term is different (`Consequence` vs `consequence`) and the `Consequence` field may contain multiple consequence terms joined by an `&` (gnomAD variants always have one consequence term).

Currently, the variant filter in `redux-variants` relies on the gnomAD format. This change makes the filter function configurable so that `redux-variants`'s consequence filter can remain agnostic about the variant data format. This also allows removing the `definitions` configuration option, which was there to support the different field name.