### PR TITLE
Size table based on container width instead of window size

### DIFF
--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -7,24 +7,19 @@
     "lib"
   ],
   "dependencies": {
+    "@broad/redux-genes": "*",
+    "@broad/redux-variants": "*",
+    "@broad/region": "*",
+    "@broad/ui": "*",
     "immutable": "^3.8.1",
+    "keymirror": "^0.1.1",
+    "prop-types": "^15.5.10",
     "react-highlight-words": "^0.8.0",
+    "react-redux": "^5.0.6",
     "react-virtualized": "^9.8.0"
   },
-  "devDependencies": {
-    "@broad/utilities": "*",
-    "@broad/region": "*",
-    "@broad/track-transcript": "*",
-    "@broad/track-variant": "*",
-    "@broad/plot": "*",
-    "@broad/track-transcript": "*",
-    "@broad/track-position-table": "*",
-    "graphql-fetch": "^1.0.1"
-  },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
     "react": "^15.5.4",
-    "ramda": "^0.24.1",
     "styled-components": "^2.1.2"
   }
 }

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -10,12 +10,12 @@
     "@broad/redux-genes": "*",
     "@broad/redux-variants": "*",
     "@broad/region": "*",
-    "@broad/ui": "*",
     "immutable": "^3.8.1",
     "keymirror": "^0.1.1",
     "prop-types": "^15.5.10",
     "react-highlight-words": "^0.8.0",
     "react-redux": "^5.0.6",
+    "react-sizeme": "^2.5.2",
     "react-virtualized": "^9.8.0"
   },
   "peerDependencies": {

--- a/packages/table/src/Table.js
+++ b/packages/table/src/Table.js
@@ -6,6 +6,7 @@ import Immutable from 'immutable'
 import PropTypes from 'prop-types'
 import React from 'react'
 import Highlighter from 'react-highlight-words'
+import { withSize } from 'react-sizeme'
 import { InfiniteLoader, List } from 'react-virtualized'
 import styled from 'styled-components'
 
@@ -582,15 +583,6 @@ const indexHeader = (
   </div>
 )
 
-const getDefaultWidth = (tableConfig) => {
-  const scrollBarWidth = 40
-  const paddingWidth = tableConfig.fields.length * 40
-  const cellContentWidth = tableConfig.fields.reduce((acc, field) =>
-    acc + field.width, 0)
-  const calculatedWidth = scrollBarWidth + paddingWidth + cellContentWidth
-  return calculatedWidth
-}
-
 const HeadersContainer = styled.div`
   display: flex;
   flex-direction: row;
@@ -623,7 +615,7 @@ const Table = ({
   onRowHover,
   onScroll,
   searchText,
-  width,
+  size,
 }) => {
   const isRowLoaded = ({ index }) => Boolean(getRowData(tableData, index))
 
@@ -636,7 +628,6 @@ const Table = ({
     onRowHover
   )
 
-  const defaultWidth = getDefaultWidth(tableConfig)
   return (
     <div>
       <TableHeaders title={title} tableConfig={tableConfig} showIndex={showIndex} />
@@ -654,7 +645,7 @@ const Table = ({
             rowHeight={25}
             rowRenderer={rowRenderer}
             overscanRowCount={overscan}
-            width={width}
+            width={size.width}
             scrollToIndex={scrollToRow}
             onScroll={onScroll}
           />
@@ -665,7 +656,6 @@ const Table = ({
 }
 Table.propTypes = {
   height: PropTypes.number.isRequired,
-  width: PropTypes.number, // eslint-disable-line
   tableConfig: PropTypes.object.isRequired,
   tableData: PropTypes.any.isRequired,
   remoteRowCount: PropTypes.number.isRequired,
@@ -676,9 +666,11 @@ Table.propTypes = {
   onRowClick: PropTypes.func,
   // onRowHover: PropTypes.func,
   searchText: PropTypes.string,
+  size: PropTypes.shape({
+    width: PropTypes.number.isRequired,
+  }),
 }
 Table.defaultProps = {
-  width: null,
   loadMoreRows: () => { },
   overscan: 10,
   showIndex: false,
@@ -686,6 +678,7 @@ Table.defaultProps = {
   setHoveredVariant: () => { },
   onRowClick: () => {},
   searchText: '',
+  size: undefined,
 }
 
-export default Table
+export default withSize()(Table)

--- a/packages/table/src/Table.js
+++ b/packages/table/src/Table.js
@@ -2,12 +2,12 @@
 /* eslint-disable no-shadow */
 /* eslint-disable no-unused-vars */
 
-import React from 'react'
-import PropTypes from 'prop-types'
-import styled from 'styled-components'
-import { InfiniteLoader, List, AutoSizer } from 'react-virtualized'
-import Highlighter from 'react-highlight-words'
 import Immutable from 'immutable'
+import PropTypes from 'prop-types'
+import React from 'react'
+import Highlighter from 'react-highlight-words'
+import { InfiniteLoader, List } from 'react-virtualized'
+import styled from 'styled-components'
 
 const abstractCellStyle = {
   paddingLeft: 10,

--- a/packages/table/src/VariantTable.js
+++ b/packages/table/src/VariantTable.js
@@ -1,29 +1,22 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable space-before-function-paren */
 /* eslint-disable no-shadow */
 /* eslint-disable comma-dangle */
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/extensions */
-
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 
-import { actions as tableActions, currentTableIndex } from '@broad/table'
-import { screenSize } from '@broad/ui'
-
+import { currentChromosome as geneChromosome } from '@broad/redux-genes'
 import {
   actions as variantActions,
   variantSearchQuery,
   finalFilteredVariants,
 } from '@broad/redux-variants'
-
-import { currentChromosome as geneChromosome } from '@broad/redux-genes'
 import { currentChromosome as regionChromosome } from '@broad/region'
+import { screenSize } from '@broad/ui'
 
-import { Table } from './index'
-
+import Table from './Table'
+import { actions as tableActions, currentTableIndex } from './tableRedux'
 
 const NoVariants = styled.div`
   display: flex;

--- a/packages/table/src/VariantTable.js
+++ b/packages/table/src/VariantTable.js
@@ -4,6 +4,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
+import { withSize } from 'react-sizeme'
 import styled from 'styled-components'
 
 import { currentChromosome as geneChromosome } from '@broad/redux-genes'
@@ -13,7 +14,6 @@ import {
   finalFilteredVariants,
 } from '@broad/redux-variants'
 import { currentChromosome as regionChromosome } from '@broad/region'
-import { screenSize } from '@broad/ui'
 
 import Table from './Table'
 import { actions as tableActions, currentTableIndex } from './tableRedux'
@@ -22,7 +22,6 @@ const NoVariants = styled.div`
   display: flex;
   align-items: center;
   height: ${props => props.height}px;
-  width: ${props => props.width}px;
   justify-content: center;
   font-weight: bold;
   font-size: 20px;
@@ -41,25 +40,20 @@ const VariantTable = ({
   tablePosition,
   searchQuery,
   title,
-  height,
   tableConfig,
-  screenSize,
+  size,
 }) => {
-  const scrollBarWidth = 40
-  const tableWidth = (screenSize.width * 0.8) + scrollBarWidth
-
   if (variants.size === 0) {
-    return <NoVariants height={500} width={tableWidth}>No variants found</NoVariants>
+    return <NoVariants height={500}>No variants found</NoVariants>
   }
 
-  const tConfig = tableConfig(setVariantSort, tableWidth, currentChromosome)
+  const tConfig = tableConfig(setVariantSort, size.width, currentChromosome)
 
   return (
     <div>
       <Table
         title={title}
         height={500}
-        width={tableWidth}
         tableConfig={tConfig}
         tableData={variants}
         remoteRowCount={variants.size}
@@ -83,21 +77,21 @@ VariantTable.propTypes = {
   tablePosition: PropTypes.number.isRequired,
   searchQuery: PropTypes.string.isRequired,
   title: PropTypes.string,
-  height: PropTypes.number,
   tableConfig: PropTypes.func.isRequired,
-  screenSize: PropTypes.object.isRequired,
+  size: PropTypes.shape({
+    width: PropTypes.number.isRequired,
+  }),
 }
 
 VariantTable.defaultProps = {
+  size: undefined,
   title: '',
-  height: 400,
 }
 const mapStateToProps = (state) => {
   return {
     variants: finalFilteredVariants(state),
     tablePosition: currentTableIndex(state),
     searchQuery: variantSearchQuery(state),
-    screenSize: screenSize(state),
     currentChromosome: geneChromosome(state) || regionChromosome(state),
   }
 }
@@ -120,4 +114,4 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(VariantTable)
+export default withSize()(connect(mapStateToProps, mapDispatchToProps)(VariantTable))

--- a/packages/ui/src/genePage/userInterface.js
+++ b/packages/ui/src/genePage/userInterface.js
@@ -47,13 +47,8 @@ export const Summary = styled.div`
 `
 
 export const TableSection = styled.div`
-  ${'' /* border: 1px solid green; */}
-  margin-bottom: 25px;
-  @media (max-width: 900px) {
-    margin-left: 5px;
-    align-items: center;
-    margin-top: 10px;
-  }
+  width: calc(80% + 40px);
+  margin: 0 auto 25px;
 `
 
 export const SettingsContainer = styled.div`

--- a/projects/gnomad/src/RegionPage/index.js
+++ b/projects/gnomad/src/RegionPage/index.js
@@ -1,72 +1,26 @@
 import React from 'react'
-import styled from 'styled-components'
 
 import { RegionHoc } from '@broad/region'
 import { VariantTable } from '@broad/table'
+import { GenePage, Summary, TableSection } from '@broad/ui'
 
 import Settings from '../Settings'
 import tableConfig from '../tableConfig'
-
 import { fetchRegion } from './fetch'
 import RegionInfo from './RegionInfo'
 import RegionViewer from './RegionViewer'
 
-
-const RegionPageWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  background-color: #FAFAFA;
-  color: black;
-  margin-top: 40px;
-  width: 95%;
-  flex-shrink: 0;
-  @media (max-width: 900px) {
-    padding-left: 0;
-    align-items: center;
-    margin-top: 80px;
-}
-`
-
-const Summary = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  width: 95%;
-  padding-left: 60px;
-  margin-bottom: 10px;
-
-  @media (max-width: 900px) {
-    padding-left: 0;
-    align-items: center;
-    justify-content: center;
-  }
-`
-
-const TableSection = styled.div`
-  margin-left: 70px;
-  margin-bottom: 100px;
-  @media (max-width: 900px) {
-    margin-left: 5px;
-    align-items: center;
-    margin-top: 10px;
-  }
-`
-
-
-const RegionPage = () => {
-  return (
-    <RegionPageWrapper>
-      <Summary>
-        <RegionInfo />
-      </Summary>
-      <RegionViewer coverageStyle={'new'} />
+const RegionPage = () => (
+  <GenePage>
+    <Summary>
+      <RegionInfo />
+    </Summary>
+    <RegionViewer coverageStyle={'new'} />
+    <TableSection>
       <Settings />
-      <TableSection>
-        <VariantTable tableConfig={tableConfig} />
-      </TableSection>
-    </RegionPageWrapper>
-  )
-}
+      <VariantTable tableConfig={tableConfig} />
+    </TableSection>
+  </GenePage>
+)
 
 export default RegionHoc(RegionPage, fetchRegion, 'gnomadCombinedVariants')

--- a/projects/schizophrenia/src/ExomePage/index.js
+++ b/projects/schizophrenia/src/ExomePage/index.js
@@ -2,10 +2,7 @@ import React from 'react'
 
 import { GenePageHoc } from '@broad/redux-genes'
 import { VariantTable } from '@broad/table'
-import {
-  GenePage,
-  Summary,
-} from '@broad/ui'
+import { GenePage, Summary, TableSection } from '@broad/ui'
 
 import VariantDetails from '../VariantDetails'
 import GeneInfo from './GeneInfo'
@@ -14,19 +11,18 @@ import RegionViewer from './RegionViewer'
 import tableConfig from './tableConfig'
 import { fetchSchz } from './fetch'
 
-
-const MainPage = () => {
-  return (
-    <GenePage>
-      <Summary>
-        <GeneInfo />
-      </Summary>
-      <RegionViewer />
+const MainPage = () => (
+  <GenePage>
+    <Summary>
+      <GeneInfo />
+    </Summary>
+    <RegionViewer />
+    <TableSection>
       <GeneSettings />
       <VariantTable tableConfig={tableConfig} />
-      <VariantDetails />
-    </GenePage>
-  )
-}
+    </TableSection>
+    <VariantDetails />
+  </GenePage>
+)
 
 export default GenePageHoc(MainPage, fetchSchz)

--- a/projects/schizophrenia/src/GeneResults.js
+++ b/projects/schizophrenia/src/GeneResults.js
@@ -16,6 +16,7 @@ import {
   Summary,
   GeneSymbol,
   Search,
+  TableSection,
 } from '@broad/ui'
 
 
@@ -141,7 +142,6 @@ class SchizophreniaGeneResults extends PureComponent {
       return <Loading><h1>Loading</h1></Loading>
     }
 
-    const tableWidth = (screenSize.width * 0.8) + 40
     const data = new List(schzGeneResults.map(e => new GeneResult(e)))
     const searchResults = data.filter((e) => {
       if (e.gene_name) {
@@ -161,19 +161,20 @@ class SchizophreniaGeneResults extends PureComponent {
           />
         </ResultsSearchWrapper>
         {sortedData.isEmpty() ? 'No results found' : (
-          <Table
-            height={800}
-            width={tableWidth}
-            tableConfig={tableConfig(this.setSortState, screenSize.width)}
-            tableData={sortedData}
-            remoteRowCount={sortedData.size}
-            loadMoreRows={() => {}}
-            overscan={5}
-            onRowClick={this.geneOnClick}
-            onRowHover={() => {}}
-            onScroll={() => {}}
-            searchText={this.state.searchText}
-          />
+          <TableSection>
+            <Table
+              height={800}
+              tableConfig={tableConfig(this.setSortState, screenSize.width)}
+              tableData={sortedData}
+              remoteRowCount={sortedData.size}
+              loadMoreRows={() => {}}
+              overscan={5}
+              onRowClick={this.geneOnClick}
+              onRowHover={() => {}}
+              onScroll={() => {}}
+              searchText={this.state.searchText}
+            />
+          </TableSection>
         )}
       </GenePage>
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1653,6 +1653,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+batch-processor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -3448,6 +3452,12 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
 electron-to-chromium@^1.3.18:
   version "1.3.21"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz#a967ebdcfe8ed0083fc244d1894022a8e8113ea2"
+
+element-resize-detector@^1.1.12:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.1.14.tgz#af064a0a618a820ad570a95c5eec5b77be0128c1"
+  dependencies:
+    batch-processor "^1.0.0"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -6503,6 +6513,10 @@ lodash.throttle@4.0.1:
   dependencies:
     lodash.debounce "^4.0.0"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+
 lodash.trimend@^4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/lodash.trimend/-/lodash.trimend-4.5.1.tgz#12804437286b98cad8996b79414e11300114082f"
@@ -8885,6 +8899,16 @@ react-select@^1.0.0-rc.10:
     prop-types "^15.5.8"
     react-input-autosize "^2.1.2"
 
+react-sizeme@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.5.2.tgz#e7041390cfb895ed15d896aa91d76e147e3b70b5"
+  dependencies:
+    element-resize-detector "^1.1.12"
+    invariant "^2.2.2"
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    shallowequal "^1.0.2"
+
 react-virtualized@^9.8.0:
   version "9.18.5"
   resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.18.5.tgz#42dd390ebaa7ea809bfcaf775d39872641679b89"
@@ -9792,6 +9816,10 @@ sha.js@~2.4.4:
 shallow-copy@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
+
+shallowequal@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
 
 shasum@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
It's much easier to reason about how a variant table component will fit into a page layout when it respects its container's size instead of sizing itself based on the window width.