### PR TITLE
Update regional constraint track's color scale

### DIFF
--- a/packages/track-regional-constraint/package.json
+++ b/packages/track-regional-constraint/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@broad/help": "*",
     "@broad/ui": "*",
+    "polished": "^1.9.3",
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {

--- a/packages/track-regional-constraint/src/RegionalConstraintTrack.js
+++ b/packages/track-regional-constraint/src/RegionalConstraintTrack.js
@@ -63,19 +63,27 @@ function regionColor(region) {
   return region.chisq_diff_null < 10.8 ? transparentize(0.8, color) : color
 }
 
+const renderNumber = number =>
+  number === undefined || number === null ? '-' : number.toPrecision(4)
+
 const WithRegionTooltip = withTooltip(({ region }) => (
   <RegionAttributeList>
     <div>
       <dt>O/E missense:</dt>
-      <dd>{region.obs_exp && region.obs_exp.toFixed(4)}</dd>
+      <dd>{renderNumber(region.obs_exp)}</dd>
     </div>
     <div>
-      <dt>&chi;<sup>2</sup>:</dt>
-      <dd>{region.chisq_diff_null && region.chisq_diff_null.toFixed(4)}</dd>
+      <dt>
+        &chi;
+        <sup>2</sup>:
+      </dt>
+      <dd>
+        {renderNumber(region.chisq_diff_null)}
+        {region.chisq_diff_null !== null && region.chisq_diff_null < 10.8 && ' (not significant)'}
+      </dd>
     </div>
   </RegionAttributeList>
 ))
-
 
 export default function RegionalConstraintTrack({
   height,

--- a/packages/track-regional-constraint/src/RegionalConstraintTrack.js
+++ b/packages/track-regional-constraint/src/RegionalConstraintTrack.js
@@ -1,3 +1,4 @@
+import { transparentize } from 'polished'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
@@ -45,22 +46,22 @@ const RegionAttributeList = styled.dl`
   }
 `
 
-
 function regionColor(region) {
-  if (region.obs_exp > 0.6 || region.chisq_diff_null < 10.8) {
-    return '#e2e2e2'
+  let color
+  if (region.obs_exp > 0.6) {
+    color = '#e2e2e2'
   }
-
   // http://colorbrewer2.org/#type=sequential&scheme=YlOrRd&n=3
   if (region.obs_exp > 0.4) {
-    return '#ffeda0'
+    color = '#ffeda0'
   }
   if (region.obs_exp > 0.2) {
-    return '#feb24c'
+    color = '#feb24c'
   }
-  return '#f03b20'
-}
+  color = '#f03b20'
 
+  return region.chisq_diff_null < 10.8 ? transparentize(0.8, color) : color
+}
 
 const WithRegionTooltip = withTooltip(({ region }) => (
   <RegionAttributeList>


### PR DESCRIPTION
Currently, regions in the regional constraint track are colored based on significance and observed/expected value. With this change, the region's hue is based _only_ on observed/expected and non significant regions are made semi-transparent. Also adds a "(not significant)" note in the tooltip.

## Before
<img width="1478" alt="screen shot 2018-09-10 at 10 57 19 am" src="https://user-images.githubusercontent.com/1156625/45305517-7e596400-b4e8-11e8-9219-b0367b5c4e57.png">

## After
<img width="1478" alt="screen shot 2018-09-10 at 10 55 01 am" src="https://user-images.githubusercontent.com/1156625/45305534-86190880-b4e8-11e8-8f16-9942ceccd850.png">
