### PR TITLE
Organize ExAC/gnomAD specific code for fetching single variants

### DIFF
--- a/packages/api/src/schema/datasets/datasetArgumentTypes.js
+++ b/packages/api/src/schema/datasets/datasetArgumentTypes.js
@@ -1,0 +1,27 @@
+import { GraphQLEnumType } from 'graphql'
+
+import datasetsConfig from './datasetsConfig'
+
+export const AllDatasetsArgumentType = new GraphQLEnumType({
+  name: 'AnyDataset',
+  values: Object.keys(datasetsConfig).reduce(
+    (values, datasetId) => ({ ...values, [datasetId]: {} }),
+    {}
+  ),
+})
+
+const methodSpecificArgumentTypes = {}
+
+export const datasetArgumentTypeForMethod = methodName => {
+  if (!methodSpecificArgumentTypes[methodName]) {
+    const typeName = `DatasetsSupporting${methodName.charAt(0).toUpperCase() + methodName.slice(1)}`
+    const type = new GraphQLEnumType({
+      name: typeName,
+      values: Object.keys(datasetsConfig)
+        .filter(datasetId => datasetsConfig[datasetId][methodName] !== undefined)
+        .reduce((values, datasetId) => ({ ...values, [datasetId]: {} }), {}),
+    })
+    methodSpecificArgumentTypes[methodName] = type
+  }
+  return methodSpecificArgumentTypes[methodName]
+}

--- a/packages/api/src/schema/datasets/datasetsConfig.js
+++ b/packages/api/src/schema/datasets/datasetsConfig.js
@@ -1,0 +1,20 @@
+import ExacVariantDetailsType from './exac/ExacVariantDetailsType'
+import fetchExacVariantDetails from './exac/fetchExacVariantDetails'
+
+import GnomadVariantDetailsType from './gnomad/GnomadVariantDetailsType'
+import fetchGnomadVariantDetails from './gnomad/fetchGnomadVariantDetails'
+
+const datasetsConfig = {
+  exac: {
+    fetchVariantDetails: fetchExacVariantDetails,
+    variantDetailsType: ExacVariantDetailsType,
+  },
+  gnomad: {
+    fetchVariantDetails: fetchGnomadVariantDetails,
+    variantDetailsType: GnomadVariantDetailsType,
+  },
+}
+
+export default datasetsConfig
+
+export const datasetSpecificTypes = [ExacVariantDetailsType, GnomadVariantDetailsType]

--- a/packages/api/src/schema/datasets/exac/ExacVariantDetailsType.js
+++ b/packages/api/src/schema/datasets/exac/ExacVariantDetailsType.js
@@ -1,0 +1,54 @@
+import {
+  GraphQLFloat,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql'
+
+import { VariantInterface } from '../../types/variant'
+import { PopulationType } from '../shared/population'
+import { VariantQualityMetricsType } from '../shared/qualityMetrics'
+import { TranscriptConsequenceType } from '../shared/transcriptConsequence'
+
+const ExacVariantDetailsType = new GraphQLObjectType({
+  name: 'ExacVariantDetails',
+  interfaces: [VariantInterface],
+  fields: {
+    // variant interface fields
+    alt: { type: new GraphQLNonNull(GraphQLString) },
+    chrom: { type: new GraphQLNonNull(GraphQLString) },
+    pos: { type: new GraphQLNonNull(GraphQLInt) },
+    ref: { type: new GraphQLNonNull(GraphQLString) },
+    variantId: { type: new GraphQLNonNull(GraphQLString) },
+    xpos: { type: new GraphQLNonNull(GraphQLFloat) },
+    // ExAC specific fields
+    ac: {
+      type: new GraphQLObjectType({
+        name: 'ExacVariantAlleleCount',
+        fields: {
+          raw: { type: GraphQLInt },
+          adj: { type: GraphQLInt },
+        },
+      }),
+    },
+    an: {
+      type: new GraphQLObjectType({
+        name: 'ExacVariantAlleleNumber',
+        fields: {
+          raw: { type: GraphQLInt },
+          adj: { type: GraphQLInt },
+        },
+      }),
+    },
+    filters: { type: new GraphQLList(GraphQLString) },
+    populations: { type: new GraphQLList(PopulationType) },
+    qualityMetrics: { type: VariantQualityMetricsType },
+    rsid: { type: GraphQLString },
+    sortedTranscriptConsequences: { type: new GraphQLList(TranscriptConsequenceType) },
+  },
+  isTypeOf: variantData => variantData.gqlType === 'ExacVariantDetails',
+})
+
+export default ExacVariantDetailsType

--- a/packages/api/src/schema/datasets/exac/fetchExacVariantDetails.js
+++ b/packages/api/src/schema/datasets/exac/fetchExacVariantDetails.js
@@ -1,61 +1,11 @@
-import {
-  GraphQLFloat,
-  GraphQLInt,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLString,
-} from 'graphql'
+import { getXpos } from '../../../utilities/variant'
 
-import { getXpos } from '../../utilities/variant'
-
-import { VariantInterface } from '../types/variant'
-import { extractPopulationData, PopulationType } from './shared/population'
-import { parseHistogram, VariantQualityMetricsType } from './shared/qualityMetrics'
-import { TranscriptConsequenceType } from './shared/transcriptConsequence'
-
-export const ExacVariantType = new GraphQLObjectType({
-  name: 'ExacVariant',
-  interfaces: [VariantInterface],
-  fields: {
-    // variant interface fields
-    alt: { type: new GraphQLNonNull(GraphQLString) },
-    chrom: { type: new GraphQLNonNull(GraphQLString) },
-    pos: { type: new GraphQLNonNull(GraphQLInt) },
-    ref: { type: new GraphQLNonNull(GraphQLString) },
-    variantId: { type: new GraphQLNonNull(GraphQLString) },
-    xpos: { type: new GraphQLNonNull(GraphQLFloat) },
-    // ExAC specific fields
-    ac: {
-      type: new GraphQLObjectType({
-        name: 'ExacVariantAlleleCount',
-        fields: {
-          raw: { type: GraphQLInt },
-          adj: { type: GraphQLInt },
-        },
-      }),
-    },
-    an: {
-      type: new GraphQLObjectType({
-        name: 'ExacVariantAlleleNumber',
-        fields: {
-          raw: { type: GraphQLInt },
-          adj: { type: GraphQLInt },
-        },
-      }),
-    },
-    filters: { type: new GraphQLList(GraphQLString) },
-    populations: { type: new GraphQLList(PopulationType) },
-    qualityMetrics: { type: VariantQualityMetricsType },
-    rsid: { type: GraphQLString },
-    sortedTranscriptConsequences: { type: new GraphQLList(TranscriptConsequenceType) },
-  },
-  isTypeOf: variantData => variantData.dataset === 'exac',
-})
+import { extractPopulationData } from '../shared/population'
+import { parseHistogram } from '../shared/qualityMetrics'
 
 const EXAC_POPULATION_IDS = ['AFR', 'AMR', 'EAS', 'FIN', 'NFE', 'OTH', 'SAS']
 
-export const fetchExacVariant = async (variantId, ctx) => {
+const fetchExacVariantDetails = async (ctx, variantId) => {
   const response = await ctx.database.elastic.search({
     index: 'exacv1',
     type: 'variant',
@@ -79,6 +29,7 @@ export const fetchExacVariant = async (variantId, ctx) => {
   const variantData = response.hits.hits[0]._source
 
   return {
+    gqlType: 'ExacVariantDetails',
     // variant interface fields
     alt: variantData.alt,
     chrom: variantData.contig,
@@ -129,3 +80,5 @@ export const fetchExacVariant = async (variantId, ctx) => {
     sortedTranscriptConsequences: JSON.parse(variantData.sortedTranscriptConsequences),
   }
 }
+
+export default fetchExacVariantDetails

--- a/packages/api/src/schema/datasets/gnomad/GnomadVariantDetailsType.js
+++ b/packages/api/src/schema/datasets/gnomad/GnomadVariantDetailsType.js
@@ -1,0 +1,85 @@
+import {
+  GraphQLFloat,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql'
+
+import { VariantInterface } from '../../types/variant'
+import { PopulationType } from '../shared/population'
+import { VariantQualityMetricsType } from '../shared/qualityMetrics'
+import { resolveReads, ReadsType } from '../shared/reads'
+import { TranscriptConsequenceType } from '../shared/transcriptConsequence'
+
+const GnomadVariantDetailsType = new GraphQLObjectType({
+  name: 'GnomadVariantDetails',
+  interfaces: [VariantInterface],
+  fields: {
+    // variant interface fields
+    alt: { type: new GraphQLNonNull(GraphQLString) },
+    chrom: { type: new GraphQLNonNull(GraphQLString) },
+    pos: { type: new GraphQLNonNull(GraphQLInt) },
+    ref: { type: new GraphQLNonNull(GraphQLString) },
+    variantId: { type: new GraphQLNonNull(GraphQLString) },
+    xpos: { type: new GraphQLNonNull(GraphQLFloat) },
+    // gnomAD specific fields
+    colocatedVariants: { type: new GraphQLList(GraphQLString) },
+    exome: {
+      type: new GraphQLObjectType({
+        name: 'GnomadVariantDetailsExomeData',
+        fields: {
+          ac: { type: GraphQLInt },
+          an: { type: GraphQLInt },
+          filters: { type: new GraphQLList(GraphQLString) },
+          populations: { type: new GraphQLList(PopulationType) },
+          qualityMetrics: { type: VariantQualityMetricsType },
+          reads: {
+            type: ReadsType,
+            resolve: async obj => {
+              if (!process.env.READS_DIR) {
+                return null
+              }
+              try {
+                return await resolveReads(process.env.READS_DIR, 'combined_bams_exomes', obj)
+              } catch (err) {
+                throw Error('Unable to load reads data')
+              }
+            },
+          },
+        },
+      }),
+    },
+    genome: {
+      type: new GraphQLObjectType({
+        name: 'GnomadVariantDetailsGenomeData',
+        fields: {
+          ac: { type: GraphQLInt },
+          an: { type: GraphQLInt },
+          filters: { type: new GraphQLList(GraphQLString) },
+          populations: { type: new GraphQLList(PopulationType) },
+          qualityMetrics: { type: VariantQualityMetricsType },
+          reads: {
+            type: ReadsType,
+            resolve: async obj => {
+              if (!process.env.READS_DIR) {
+                return null
+              }
+              try {
+                return await resolveReads(process.env.READS_DIR, 'combined_bams_genomes', obj)
+              } catch (err) {
+                throw Error('Unable to load reads data')
+              }
+            },
+          },
+        },
+      }),
+    },
+    rsid: { type: GraphQLString },
+    sortedTranscriptConsequences: { type: new GraphQLList(TranscriptConsequenceType) },
+  },
+  isTypeOf: variantData => variantData.gqlType === 'GnomadVariantDetails',
+})
+
+export default GnomadVariantDetailsType


### PR DESCRIPTION
Dataset specific code for ExAC and gnomAD is going to quickly outgrow the single files `exac.js` and `gnomad.js`. Split those up into folders with one function/class per file.

Create `datasetsConfig.js` with the dataset specific implementation of each generic function/type (`fetchVariantDetails`, `fetchVariantsInGene`, etc) so that code in the `schema/types` folder doesn't have to deal with importing the implementation for every dataset.