### PR TITLE
Tweaks to Combobox component

### DIFF
--- a/packages/ui/src/Combobox.js
+++ b/packages/ui/src/Combobox.js
@@ -29,6 +29,7 @@ const Input = styled.input`
 const Item = styled.div`
   padding: 0.375em 0.75em;
   background: ${props => (props.isHighlighted ? transparentize(0.5, '#428bca') : 'none')};
+  cursor: pointer;
   font-size: 14px;
 `
 

--- a/packages/ui/src/Combobox.js
+++ b/packages/ui/src/Combobox.js
@@ -93,6 +93,9 @@ export class Combobox extends Component {
           onBlur: () => {
             this.setState({ inputValue: this.props.value })
           },
+          onFocus: () => {
+            this.setState({ inputValue: '' })
+          },
         }}
         items={this.props.options}
         menuStyle={menuStyle}

--- a/packages/ui/src/Combobox.js
+++ b/packages/ui/src/Combobox.js
@@ -67,7 +67,8 @@ export class Combobox extends Component {
   }
 
   onSelect = value => {
-    this.setState({ inputValue: value })
+    const selectedOption = this.props.options.find(opt => opt.value === value)
+    this.setState({ inputValue: selectedOption.label })
     this.props.onChange(value)
   }
 

--- a/packages/ui/src/Combobox.js
+++ b/packages/ui/src/Combobox.js
@@ -5,6 +5,8 @@ import Autocomplete from 'react-autocomplete'
 import styled from 'styled-components'
 
 const Input = styled.input`
+  box-sizing: border-box;
+  max-width: 100%;
   padding: 0.375em 1.5em 0.375em 0.75em;
   border-color: #6c757d;
   border-style: solid;
@@ -49,10 +51,12 @@ export class Combobox extends Component {
       PropTypes.shape({ label: PropTypes.string.isRequired, value: PropTypes.string.isRequired })
     ).isRequired,
     value: PropTypes.string.isRequired,
+    width: PropTypes.string,
   }
 
   static defaultProps = {
     id: undefined,
+    width: undefined,
   }
 
   constructor(props) {
@@ -97,6 +101,10 @@ export class Combobox extends Component {
         )}
         shouldItemRender={this.shouldItemRender}
         value={this.state.inputValue}
+        wrapperStyle={{
+          display: 'inline-block',
+          width: this.props.width,
+        }}
         onChange={this.onChange}
         onSelect={this.onSelect}
       />

--- a/packages/ui/src/Combobox.js
+++ b/packages/ui/src/Combobox.js
@@ -76,23 +76,18 @@ export class Combobox extends Component {
   renderInput = props => {
     // eslint-disable-next-line react/prop-types
     const { ref, ...rest } = props
-    return (
-      <Input
-        {...rest}
-        id={this.props.id}
-        innerRef={ref}
-        onBlur={e => {
-          props.onBlur(e)
-          this.setState({ inputValue: this.props.value })
-        }}
-      />
-    )
+    return <Input {...rest} id={this.props.id} innerRef={ref} />
   }
 
   render() {
     return (
       <Autocomplete
         getItemValue={item => item.value}
+        inputProps={{
+          onBlur: () => {
+            this.setState({ inputValue: this.props.value })
+          },
+        }}
         items={this.props.options}
         menuStyle={menuStyle}
         renderInput={this.renderInput}


### PR DESCRIPTION
* Fix reset value when input is blurred. Move the input's onBlur handler to Autocomplete's inputProps to prevent it from being fired when a menu item is clicked.
* Fix onSelect handler. When an item is selected, display the item's label instead of its value.
* Add optional width prop.
* Update menu item style.
* Clear combobox input when it is focused so that all menu items are initially visible