### PR TITLE
Restyle dataset selection on gene and region pages

### DIFF
--- a/packages/region/src/RegionHoc.js
+++ b/packages/region/src/RegionHoc.js
@@ -73,7 +73,7 @@ const RegionPageContainer = ComposedComponent => class RegionPage extends Compon
 
     if (this.state.regionData) {
       return (
-        <ComposedComponent regionData={this.state.regionData} />
+        <ComposedComponent region={this.state.regionData} />
       )
     }
 

--- a/packages/ui/src/Page.js
+++ b/packages/ui/src/Page.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+import React from 'react'
 import styled from 'styled-components'
 
 export const Page = styled.div`
@@ -9,14 +11,58 @@ export const Page = styled.div`
   font-size: 14px;
 `
 
-export const PageHeading = styled.h1`
+const PageHeadingWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
   padding-bottom: 0.5em;
   border-bottom: 1px solid #ccc;
-  margin: 0.5em 0 1em;
+  margin: 0.67em 0;
   font-size: 36px;
+
+  @media (max-width: 900px) {
+    flex-direction: column;
+    align-items: center;
+    border-bottom: none;
+  }
 `
+const PageHeadingText = styled.h1`
+  margin: 0;
+  font-size: 1em;
+
+  @media (max-width: 900px) {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-bottom: 0.5em;
+    border-bottom: 1px solid #ccc;
+    margin-bottom: 0.5em;
+  }
+`
+
+const PageControlsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+`
+
+export const PageHeading = ({ children, renderPageControls }) => (
+  <PageHeadingWrapper>
+    <PageHeadingText>{children}</PageHeadingText>
+    {renderPageControls && <PageControlsWrapper>{renderPageControls()}</PageControlsWrapper>}
+  </PageHeadingWrapper>
+)
+
+PageHeading.propTypes = {
+  children: PropTypes.node.isRequired,
+  renderPageControls: PropTypes.func,
+}
+
+PageHeading.defaultProps = {
+  renderPageControls: undefined,
+}
 
 export const SectionHeading = styled.h2`
   margin: 0 0 0.5em;
-  font-size: 24px;
+  font-size: 18px;
 `

--- a/projects/gnomad/src/GenePage/Constraint.js
+++ b/projects/gnomad/src/GenePage/Constraint.js
@@ -1,132 +1,49 @@
-import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import React from 'react'
+import { connect } from 'react-redux'
 
-import { QuestionMark } from '@broad/help'
-import {
-  SectionTitle,
-  ItemWrapper,
-  Table,
-  TableRows,
-  TableRow,
-  TableHeader,
-  TableCell,
-  TableTitleColumn,
-} from '@broad/ui'
+import { geneData } from '@broad/redux-genes'
+import { selectedVariantDataset } from '@broad/redux-variants'
+import { Table, TableCell, TableHeader, TableRow, TableRows, TableTitleColumn } from '@broad/ui'
 
-
-const ConstraintTabletop = styled.div`
-  display: flex;
-  flex-direction: row;
-
-  margin-bottom: 20px;
-  align-items: center;
-  width: 100%;
-`
-
-const ConstraintSectionTitle = SectionTitle.extend`
-  display: flex;
-  flex-direction: row;
-  width: 60%;
-  margin: 0;
-`
-
-const DatasetSelectionWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  flex-grow: 1;
-  justify-content: flex-end;
-`
-
-const DatasetSelection = styled.div`
-  margin-right: 5px;
-  font-weight: ${({ isActive }) => isActive ? 'bold' : 'normal'};
-  cursor: pointer;
-`
-
-const ConstraintTableHeader = ({ selectedVariantDataset, setSelectedVariantDataset }) => (
-  <ConstraintTabletop>
-    <ConstraintSectionTitle>
-      Gene constraint
-      <QuestionMark topic={'gene-constraint'} />
-    </ConstraintSectionTitle>
-    <DatasetSelectionWrapper>
-      <DatasetSelection
-        isActive={selectedVariantDataset === 'exacVariants'}
-        onClick={() => setSelectedVariantDataset('exacVariants')}
-      >
-        ExAC
-      </DatasetSelection>
-      <DatasetSelection>
-        {'|'}
-      </DatasetSelection>
-      <DatasetSelection
-        isActive={selectedVariantDataset === 'gnomadCombinedVariants'}
-        onClick={() => setSelectedVariantDataset('gnomadCombinedVariants')}
-      >
-        gnomAD
-      </DatasetSelection>
-    </DatasetSelectionWrapper>
-  </ConstraintTabletop>
-)
-
-ConstraintTableHeader.propTypes = {
-  selectedVariantDataset: PropTypes.string.isRequired,
-  setSelectedVariantDataset: PropTypes.func.isRequired,
-}
-
-
-export const ConstraintTable = ({
-  constraintData,
-  selectedVariantDataset,
-  setSelectedVariantDataset,
-}) => (
-  <ItemWrapper>
-    <ConstraintTableHeader
-      selectedVariantDataset={selectedVariantDataset}
-      setSelectedVariantDataset={setSelectedVariantDataset}
-    />
-    <Table>
-      <TableRows>
-        <TableHeader>
-          <TableTitleColumn />
-          <TableCell width={'40%'}>Category</TableCell>
-          <TableCell width={'20%'}>Exp. no. variants</TableCell>
-          <TableCell width={'20%'}>Obs. no. variants</TableCell>
-          <TableCell width={'20%'}>Constraint metric</TableCell>
-        </TableHeader>
-        <TableRow>
-          <TableTitleColumn />
-          <TableCell width={'40%'}>Synonymous</TableCell>
-          <TableCell width={'20%'}>{constraintData.exp_syn.toFixed(1)}</TableCell>
-          <TableCell width={'20%'}>{constraintData.n_syn}</TableCell>
-          <TableCell width={'20%'}>Z = {constraintData.syn_z.toFixed(2)}</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableTitleColumn />
-          <TableCell width={'40%'}>Missense</TableCell>
-          <TableCell width={'20%'}>{constraintData.exp_mis.toFixed(1)}</TableCell>
-          <TableCell width={'20%'}>{constraintData.n_mis}</TableCell>
-          <TableCell width={'20%'}>Z = {constraintData.mis_z.toFixed(2)}</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableTitleColumn />
-          <TableCell width={'40%'}>LoF</TableCell>
-          <TableCell width={'20%'}>{constraintData.exp_lof.toFixed(1)}</TableCell>
-          <TableCell width={'20%'}>{constraintData.n_lof}</TableCell>
-          <TableCell width={'20%'}>pLI = {constraintData.pLI.toFixed(2)}</TableCell>
-        </TableRow>
-      </TableRows>
-    </Table>
-  </ItemWrapper>
+const ConstraintTable = ({ constraintData }) => (
+  <Table>
+    <TableRows>
+      <TableHeader>
+        <TableTitleColumn />
+        <TableCell width={'40%'}>Category</TableCell>
+        <TableCell width={'20%'}>Exp. no. variants</TableCell>
+        <TableCell width={'20%'}>Obs. no. variants</TableCell>
+        <TableCell width={'20%'}>Constraint metric</TableCell>
+      </TableHeader>
+      <TableRow>
+        <TableTitleColumn />
+        <TableCell width={'40%'}>Synonymous</TableCell>
+        <TableCell width={'20%'}>{constraintData.exp_syn.toFixed(1)}</TableCell>
+        <TableCell width={'20%'}>{constraintData.n_syn}</TableCell>
+        <TableCell width={'20%'}>Z = {constraintData.syn_z.toFixed(2)}</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableTitleColumn />
+        <TableCell width={'40%'}>Missense</TableCell>
+        <TableCell width={'20%'}>{constraintData.exp_mis.toFixed(1)}</TableCell>
+        <TableCell width={'20%'}>{constraintData.n_mis}</TableCell>
+        <TableCell width={'20%'}>Z = {constraintData.mis_z.toFixed(2)}</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableTitleColumn />
+        <TableCell width={'40%'}>LoF</TableCell>
+        <TableCell width={'20%'}>{constraintData.exp_lof.toFixed(1)}</TableCell>
+        <TableCell width={'20%'}>{constraintData.n_lof}</TableCell>
+        <TableCell width={'20%'}>pLI = {constraintData.pLI.toFixed(2)}</TableCell>
+      </TableRow>
+    </TableRows>
+  </Table>
 )
 
 ConstraintTable.propTypes = {
   constraintData: PropTypes.object.isRequired,
-  selectedVariantDataset: PropTypes.string.isRequired,
-  setSelectedVariantDataset: PropTypes.func.isRequired,
 }
-
 
 const PlaceholderTable = Table.extend`
   opacity: 0.4;
@@ -136,47 +53,54 @@ const ConstraintMessage = TableCell.extend`
   text-align: center;
 `
 
-export const ConstraintTablePlaceholder = ({
-  message,
-  selectedVariantDataset,
-  setSelectedVariantDataset,
-}) => (
-  <ItemWrapper>
-    <ConstraintTableHeader
-      selectedVariantDataset={selectedVariantDataset}
-      setSelectedVariantDataset={setSelectedVariantDataset}
-    />
-    <PlaceholderTable>
-      <TableRows>
-        <TableHeader>
-          <TableTitleColumn />
-          <TableCell width={'40%'}>Category</TableCell>
-          <TableCell>Exp. no. variants</TableCell>
-          <TableCell>Obs. no. variants</TableCell>
-          <TableCell>Constraint metric</TableCell>
-        </TableHeader>
-        <TableRow>
-          <TableTitleColumn />
-          <TableCell width={'40%'}>Synonymous</TableCell>
-          <TableCell width={'60%'} />
-        </TableRow>
-        <TableRow>
-          <TableTitleColumn />
-          <TableCell width={'40%'}>Missense</TableCell>
-          <ConstraintMessage width={'60%'}>{message}</ConstraintMessage>
-        </TableRow>
-        <TableRow>
-          <TableTitleColumn />
-          <TableCell width={'40%'}>LoF</TableCell>
-          <TableCell width={'60%'} />
-        </TableRow>
-      </TableRows>
-    </PlaceholderTable>
-  </ItemWrapper>
+const ConstraintTablePlaceholder = ({ message }) => (
+  <PlaceholderTable>
+    <TableRows>
+      <TableHeader>
+        <TableTitleColumn />
+        <TableCell width={'40%'}>Category</TableCell>
+        <TableCell>Exp. no. variants</TableCell>
+        <TableCell>Obs. no. variants</TableCell>
+        <TableCell>Constraint metric</TableCell>
+      </TableHeader>
+      <TableRow>
+        <TableTitleColumn />
+        <TableCell width={'40%'}>Synonymous</TableCell>
+        <TableCell width={'60%'} />
+      </TableRow>
+      <TableRow>
+        <TableTitleColumn />
+        <TableCell width={'40%'}>Missense</TableCell>
+        <ConstraintMessage width={'60%'}>{message}</ConstraintMessage>
+      </TableRow>
+      <TableRow>
+        <TableTitleColumn />
+        <TableCell width={'40%'}>LoF</TableCell>
+        <TableCell width={'60%'} />
+      </TableRow>
+    </TableRows>
+  </PlaceholderTable>
 )
 
 ConstraintTablePlaceholder.propTypes = {
   message: PropTypes.string.isRequired,
-  selectedVariantDataset: PropTypes.string.isRequired,
-  setSelectedVariantDataset: PropTypes.func.isRequired,
 }
+
+export const ConstraintTableOrPlaceholder = connect(state => ({
+  geneData: geneData(state).toJS(),
+  selectedVariantDataset: selectedVariantDataset(state),
+}))(({ geneData, selectedVariantDataset }) => {
+  if (selectedVariantDataset === 'exacVariants') {
+    const exacConstraint = geneData.exacv1_constraint
+    if (!exacConstraint) {
+      return <ConstraintTablePlaceholder message="ExAC constraint not available for this gene" />
+    }
+    return <ConstraintTable constraintData={exacConstraint} />
+  }
+
+  if (selectedVariantDataset === 'gnomadCombinedVariants') {
+    return <ConstraintTablePlaceholder message="gnomAD constraint coming soon!" />
+  }
+
+  return null
+})

--- a/projects/gnomad/src/GenePage/GeneInfo.js
+++ b/projects/gnomad/src/GenePage/GeneInfo.js
@@ -1,24 +1,11 @@
-/* eslint-disable import/no-extraneous-dependencies */
-/* eslint-disable camelcase */
-
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
-import { geneData, regionalConstraint, currentTranscript } from '@broad/redux-genes'
+import { currentTranscript, geneData } from '@broad/redux-genes'
+import { variantCount } from '@broad/redux-variants'
 
 import {
-  variantCount,
-  selectedVariantDataset,
-  actions as variantActions,
-} from '@broad/redux-variants'
-
-import {
-  GeneInfoWrapper,
-  GeneNameWrapper,
-  GeneSymbol,
-  GeneLongName,
-  GeneDetails,
   GeneAttributes,
   GeneAttributeKeys,
   GeneAttributeKey,
@@ -26,178 +13,89 @@ import {
   GeneAttributeValue,
 } from '@broad/ui'
 
-
-import { ConstraintTable, ConstraintTablePlaceholder } from './Constraint'
-
-const GeneInfo = ({
-  geneData,
-  variantCount,
-  selectedVariantDataset,
-  setSelectedVariantDataset,
-  regionalConstraint,
-  currentTranscript,
-}) => {
+const GeneInfo = ({ currentTranscript, gene, variantCount }) => {
   const {
-    gene_name,
-    gene_id,
+    canonical_transcript: canonicalTranscript,
+    chrom,
+    gene_name: geneName,
+    gene_id: geneId,
+    omim_accession: omimAccession,
     start,
     stop,
-    chrom,
-    full_gene_name,
-    omim_accession,
-    exacv1_constraint,
-    canonical_transcript,
-  } = geneData.toJS()
+  } = gene
+
+  const ensemblGeneUrl = `http://www.ensembl.org/Homo_sapiens/Gene/Summary?g=${geneId}`
+  const ensemblTranscriptUrl = `http://www.ensembl.org/Homo_sapiens/Transcript/Summary?t=${currentTranscript ||
+    canonicalTranscript}`
+  const ucscUrl = `http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr${chrom}%3A${start -
+    1}-${stop}`
+  const geneCardsUrl = `http://www.genecards.org/cgi-bin/carddisp.pl?gene=${geneName}`
+  const omimUrl = `http://omim.org/entry/${omimAccession}`
+
   return (
-    <GeneInfoWrapper>
-      <GeneNameWrapper>
-        <GeneSymbol>{gene_name}</GeneSymbol>
-        <GeneLongName>{full_gene_name}</GeneLongName>
-      </GeneNameWrapper>
-      <GeneDetails>
-        <GeneAttributes>
-          <GeneAttributeKeys>
-            <GeneAttributeKey>
-              Ensembl gene ID
-            </GeneAttributeKey>
-            <GeneAttributeKey>
-              Ensembl transcript ID
-            </GeneAttributeKey>
-            <GeneAttributeKey>
-              Number of variants
-            </GeneAttributeKey>
-            <GeneAttributeKey>
-              UCSC Browser
-            </GeneAttributeKey>
-            <GeneAttributeKey>
-              GeneCards
-            </GeneAttributeKey>
-            <GeneAttributeKey>
-              OMIM
-            </GeneAttributeKey>
-            {/* <GeneAttributeKey>
-              External references
-            </GeneAttributeKey> */}
-          </GeneAttributeKeys>
-          <GeneAttributeValues>
-            <GeneAttributeValue>
-              <a
-                target="_blank"
-                href={`http://www.ensembl.org/Homo_sapiens/Gene/Summary?g=${gene_id}`}
-              >
-                {gene_id}
-              </a>
-            </GeneAttributeValue>
-            <GeneAttributeValue>
-              <a
-                target="_blank"
-                href={`http://www.ensembl.org/Homo_sapiens/Transcript/Summary?t=${currentTranscript || canonical_transcript}`}
-              >
-                {currentTranscript || canonical_transcript}
-                {(currentTranscript === null || currentTranscript === canonical_transcript) && ' (canonical)'}
-              </a>
-            </GeneAttributeValue>
-            <GeneAttributeValue>
-              {variantCount}
-            </GeneAttributeValue>
-            <GeneAttributeValue>
-              <a
-                target="_blank"
-                href={`http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr${chrom}%3A${start - 1}-${stop}`}
-              >
-                {`${chrom}:${start}:${stop}`}
-              </a>
-            </GeneAttributeValue>
-            <GeneAttributeValue>
-              <a
-                target="_blank"
-                href={`http://www.genecards.org/cgi-bin/carddisp.pl?gene=${gene_name}`}
-              >
-                {gene_name}
-              </a>
-            </GeneAttributeValue>
-            <GeneAttributeValue>
-              <a
-                target="_blank"
-                href={`http://omim.org/entry/${omim_accession}`}
-              >
-                {omim_accession || 'N/A'}
-              </a>
-            </GeneAttributeValue>
-            {/* <GeneAttributeValue>
-              <a
-                target="_blank"
-                href={`http://en.wikipedia.org/wiki/${gene_name}`}
-              >
-                PubMed
-              </a>
-            </GeneAttributeValue>
-            <GeneAttributeValue>
-              <a
-                target="_blank"
-                href={`http://en.wikipedia.org/wiki/${gene_name}`}
-              >
-                Wikipedia
-              </a>
-            </GeneAttributeValue>
-            <GeneAttributeValue>
-              <a
-                target="_blank"
-                href={`http://www.wikigenes.org/?search=${gene_name}`}
-              >
-                Wikigenes
-              </a>
-            </GeneAttributeValue>
-            <GeneAttributeValue>
-              <a
-                target="_blank"
-                href={`http://www.gtexportal.org/home/gene/${gene_name}`}
-              >
-                GTEx (Expression)
-              </a>
-            </GeneAttributeValue> */}
-          </GeneAttributeValues>
-        </GeneAttributes>
-        {selectedVariantDataset === 'exacVariants' && exacv1_constraint &&
-          <ConstraintTable
-            constraintData={exacv1_constraint}
-            setSelectedVariantDataset={setSelectedVariantDataset}
-            selectedVariantDataset={selectedVariantDataset}
-          />}
-        {selectedVariantDataset === 'exacVariants' && !exacv1_constraint &&
-        <ConstraintTablePlaceholder
-          message={'ExAC constraint not available for this gene'}
-          setSelectedVariantDataset={setSelectedVariantDataset}
-          selectedVariantDataset={selectedVariantDataset}
-        />}
-        {selectedVariantDataset === 'gnomadCombinedVariants' &&
-          <ConstraintTablePlaceholder
-            message={'gnomAD constraint coming soon!'}
-            setSelectedVariantDataset={setSelectedVariantDataset}
-            selectedVariantDataset={selectedVariantDataset}
-          />}
-      </GeneDetails>
-    </GeneInfoWrapper>
+    <GeneAttributes>
+      <GeneAttributeKeys>
+        <GeneAttributeKey>Ensembl gene ID</GeneAttributeKey>
+        <GeneAttributeKey>Ensembl transcript ID</GeneAttributeKey>
+        <GeneAttributeKey>Number of variants</GeneAttributeKey>
+        <GeneAttributeKey>UCSC Browser</GeneAttributeKey>
+        <GeneAttributeKey>GeneCards</GeneAttributeKey>
+        <GeneAttributeKey>OMIM</GeneAttributeKey>
+      </GeneAttributeKeys>
+      <GeneAttributeValues>
+        <GeneAttributeValue>
+          <a target="_blank" href={ensemblGeneUrl}>
+            {geneId}
+          </a>
+        </GeneAttributeValue>
+        <GeneAttributeValue>
+          <a target="_blank" href={ensemblTranscriptUrl}>
+            {currentTranscript || canonicalTranscript}
+            {(currentTranscript === null || currentTranscript === canonicalTranscript) &&
+              ' (canonical)'}
+          </a>
+        </GeneAttributeValue>
+        <GeneAttributeValue>{variantCount}</GeneAttributeValue>
+        <GeneAttributeValue>
+          <a target="_blank" href={ucscUrl}>
+            {`${chrom}:${start}:${stop}`}
+          </a>
+        </GeneAttributeValue>
+        <GeneAttributeValue>
+          <a target="_blank" href={geneCardsUrl}>
+            {geneName}
+          </a>
+        </GeneAttributeValue>
+        <GeneAttributeValue>
+          <a target="_blank" href={omimUrl}>
+            {omimAccession || 'N/A'}
+          </a>
+        </GeneAttributeValue>
+      </GeneAttributeValues>
+    </GeneAttributes>
   )
 }
 
 GeneInfo.propTypes = {
-  geneData: PropTypes.object.isRequired,
+  currentTranscript: PropTypes.string,
+  gene: PropTypes.shape({
+    canonical_transcript: PropTypes.string.isRequired,
+    chrom: PropTypes.string.isRequired,
+    gene_name: PropTypes.string.isRequired,
+    gene_id: PropTypes.string.isRequired,
+    omim_accession: PropTypes.string.isRequired,
+    start: PropTypes.number.isRequired,
+    stop: PropTypes.number.isRequired,
+  }).isRequired,
   variantCount: PropTypes.number.isRequired,
-  selectedVariantDataset: PropTypes.string.isRequired,
-  regionalConstraint: PropTypes.array,
 }
 
-export default connect(
-  state => ({
-    geneData: geneData(state),
-    variantCount: variantCount(state),
-    selectedVariantDataset: selectedVariantDataset(state),
-    regionalConstraint: regionalConstraint(state),
-    currentTranscript: currentTranscript(state),
-  }),
-  dispatch => ({
-    setSelectedVariantDataset: dataset =>
-      dispatch(variantActions.setSelectedVariantDataset(dataset)),
-  })
-)(GeneInfo)
+GeneInfo.defaultProps = {
+  currentTranscript: undefined,
+}
+
+export default connect(state => ({
+  currentTranscript: currentTranscript(state),
+  gene: geneData(state).toJS(),
+  variantCount: variantCount(state),
+}))(GeneInfo)

--- a/projects/gnomad/src/GenePage/index.js
+++ b/projects/gnomad/src/GenePage/index.js
@@ -1,29 +1,27 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 
+import { QuestionMark } from '@broad/help'
 import { GenePageHoc } from '@broad/redux-genes'
 import { actions as variantActions } from '@broad/redux-variants'
 import { VariantTable } from '@broad/table'
-import {
-  GenePage,
-  Summary,
-  TableSection,
-  ClassicExacButton,
-} from '@broad/ui'
+import { ClassicExacButton, GenePage, SectionHeading, TableSection } from '@broad/ui'
 
+import GnomadPageHeading from '../GnomadPageHeading'
+import Settings from '../Settings'
+import tableConfig from '../tableConfig'
+import { ConstraintTableOrPlaceholder } from './Constraint'
 import { exportFetch } from './exportFetch'
 import { fetchGnomadGenePage } from './fetch'
 import GeneInfo from './GeneInfo'
-import Settings from '../Settings'
 import GeneViewer from './RegionViewer'
-import tableConfig from '../tableConfig'
-
 
 const BottomButtonSection = styled.div`
-  width: 100%;
   display: flex;
   justify-content: center;
+  width: 100%;
   margin-top: 20px;
 `
 
@@ -34,25 +32,70 @@ const ExportVariantsButton = connect(
   })
 )(ClassicExacButton)
 
+/**
+ * FIXME
+ * This section previously had a 97% width left aligned div nested in a 90% width centered div.
+ * This imitates the same layout with fewer elements. The horizontal alignment of various sections
+ * needs to be made consistent.
+ */
+const GeneInfoSection = styled.div`
+  width: 87%;
+  padding-right: 3%;
+  margin-bottom: 10px;
+`
 
-const GenePageConnected = () => {
+const GeneFullName = styled.span`
+  font-size: 22px;
+  font-weight: 400;
+`
+
+const GeneInfoColumnWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+
+  @media (max-width: 900px) {
+    flex-direction: column;
+    align-items: center;
+  }
+`
+
+const GenePageConnected = ({ gene }) => {
+  console.log(gene)
+  const { gene_name: geneSymbol, full_gene_name: fullGeneName } = gene
   return (
     <GenePage>
-      <Summary>
-        <GeneInfo />
-      </Summary>
+      <GeneInfoSection>
+        <GnomadPageHeading>
+          {geneSymbol} <GeneFullName>{fullGeneName}</GeneFullName>
+        </GnomadPageHeading>
+        <GeneInfoColumnWrapper>
+          <GeneInfo />
+          <div>
+            <SectionHeading>
+              Gene Constraint <QuestionMark display="inline" topic="gene-constraint" />
+            </SectionHeading>
+            <ConstraintTableOrPlaceholder />
+          </div>
+        </GeneInfoColumnWrapper>
+      </GeneInfoSection>
       <GeneViewer />
       <TableSection>
         <Settings />
         <VariantTable tableConfig={tableConfig} />
         <BottomButtonSection>
-          <ExportVariantsButton>
-            Export variants
-          </ExportVariantsButton>
+          <ExportVariantsButton>Export variants</ExportVariantsButton>
         </BottomButtonSection>
       </TableSection>
     </GenePage>
   )
+}
+
+GenePageConnected.propTypes = {
+  gene: PropTypes.shape({
+    gene_name: PropTypes.string.isRequired,
+    full_gene_name: PropTypes.string.isRequired,
+  }).isRequired,
 }
 
 export default GenePageHoc(GenePageConnected, fetchGnomadGenePage)

--- a/projects/gnomad/src/GnomadPageHeading.js
+++ b/projects/gnomad/src/GnomadPageHeading.js
@@ -1,0 +1,49 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { connect } from 'react-redux'
+
+import { QuestionMark } from '@broad/help'
+import { actions as variantActions, selectedVariantDataset } from '@broad/redux-variants'
+import { Combobox, PageHeading } from '@broad/ui'
+
+const datasetLabels = {
+  exacVariants: 'ExAC',
+  gnomadCombinedVariants: 'gnomAD',
+}
+
+const GnomadPageHeading = connect(
+  state => ({ selectedVariantDataset: selectedVariantDataset(state) }),
+  dispatch => ({
+    setSelectedVariantDataset: dataset =>
+      dispatch(variantActions.setSelectedVariantDataset(dataset)),
+  })
+)(({ children, selectedVariantDataset, setSelectedVariantDataset }) => (
+  <PageHeading
+    renderPageControls={() => (
+      <div>
+        {/* eslint-disable jsx-a11y/label-has-for */}
+        <label htmlFor="dataset-selector">Current Dataset </label>
+        <Combobox
+          id="dataset-selector"
+          options={['gnomadCombinedVariants', 'exacVariants'].map(datasetId => ({
+            label: datasetLabels[datasetId],
+            value: datasetId,
+          }))}
+          value={datasetLabels[selectedVariantDataset]}
+          width="100px"
+          onChange={setSelectedVariantDataset}
+        />
+
+        <QuestionMark topic={'dataset-selection'} display={'inline'} />
+      </div>
+    )}
+  >
+    {children}
+  </PageHeading>
+))
+
+GnomadPageHeading.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+export default GnomadPageHeading

--- a/projects/gnomad/src/RegionPage/RegionInfo.js
+++ b/projects/gnomad/src/RegionPage/RegionInfo.js
@@ -1,6 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
-/* eslint-disable camelcase */
-
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
@@ -9,10 +6,6 @@ import { regionData } from '@broad/region'
 import { variantCount } from '@broad/redux-variants'
 
 import {
-  GeneInfoWrapper,
-  GeneNameWrapper,
-  GeneSymbol,
-  GeneDetails,
   GeneAttributes,
   GeneAttributeKeys,
   GeneAttributeKey,
@@ -20,109 +13,31 @@ import {
   GeneAttributeValue,
 } from '@broad/ui'
 
-const lof = '#DD2C00'
-const missense = 'orange'
-const synonymous = '#2E7D32'
-const other = '#424242'
-const consequencePresentation = {
-  missense_variant: { name: 'missense', color: missense },
-  synonymous_variant: { name: 'synonymous', color: synonymous },
-  upstream_gene_variant: { name: 'upstream gene', color: other },
-  downstream_gene_variant: { name: 'downstream gene', color: other },
-  intron_variant: { name: 'intron', color: other },
-  '3_prime_UTR_variant': { name: "3' UTR", color: other },
-  splice_region_variant: { name: 'splice region', color: lof },
-  frameshift_variant: { name: 'frameshift', color: lof },
-  stop_gained: { name: 'stop gained', color: lof },
-  inframe_deletion: { name: 'inframe deletion', color: lof },
-}
-
-const GeneAttributesConsequenceCounts = GeneAttributes.extend`
-  max-height: 100px;
-  flex-wrap: wrap;
-  border: 1px solid #000;
-`
-
-const getConsequenceColor = (consequence) => {
-  if (consequence in consequencePresentation) {
-    return consequencePresentation[consequence].color
-  }
-  return other
-}
-const getConsequenceName = (consequence) => {
-  if (consequence in consequencePresentation) {
-    return consequencePresentation[consequence].name
-  }
-  return consequence
-}
-
-const RegionInfo = ({ regionData, variantCount }) => {
-  const {
-    start,
-    stop,
-    chrom,
-    gnomad_consequence_buckets: { total_consequence_counts }
-  } = regionData.toJS()
-  const getTotalVariants = (totalConsequenceCounts) => {
-    return totalConsequenceCounts.reduce((acc, { consequence, count }) => {
-      return count + acc
-    }, 0)
-  }
-  const total = getTotalVariants(total_consequence_counts)
+const RegionInfo = ({ region, variantCount }) => {
+  const { start, stop } = region
   return (
-    <GeneInfoWrapper>
-      <GeneNameWrapper>
-        <GeneSymbol>{`${chrom}-${start}-${stop}`}</GeneSymbol>
-      </GeneNameWrapper>
-      <GeneDetails>
-        <GeneAttributes>
-          <GeneAttributeKeys>
-            <GeneAttributeKey>
-              Region size:
-            </GeneAttributeKey>
-            <GeneAttributeKey>
-              Total variants:
-            </GeneAttributeKey>
-
-          </GeneAttributeKeys>
-          <GeneAttributeValues>
-            <GeneAttributeValue>
-              {(stop - start).toLocaleString()} BP
-            </GeneAttributeValue>
-            <GeneAttributeValue>
-              {total.toLocaleString()}
-            </GeneAttributeValue>
-          </GeneAttributeValues>
-        </GeneAttributes>
-        {/* <GeneAttributesConsequenceCounts>
-          <GeneAttributeKeys>
-            {total_consequence_counts.map(({ consequence, count }) => (
-              <GeneAttributeKey key={`${consequence}-key`}>
-                <strong style={{ color: getConsequenceColor(consequence) }}>{getConsequenceName(consequence)}</strong>
-              </GeneAttributeKey>
-            ))}
-          </GeneAttributeKeys>
-          <GeneAttributeValues>
-            {total_consequence_counts.map(({ consequence, count }) => (
-              <GeneAttributeValue key={`${consequence}-value`}>
-                {count.toLocaleString()}
-              </GeneAttributeValue>
-            ))}
-          </GeneAttributeValues>
-        </GeneAttributesConsequenceCounts> */}
-      </GeneDetails>
-    </GeneInfoWrapper>
+    <GeneAttributes>
+      <GeneAttributeKeys>
+        <GeneAttributeKey>Region size</GeneAttributeKey>
+        <GeneAttributeKey>Total variants</GeneAttributeKey>
+      </GeneAttributeKeys>
+      <GeneAttributeValues>
+        <GeneAttributeValue>{(stop - start).toLocaleString()} BP</GeneAttributeValue>
+        <GeneAttributeValue>{variantCount.toLocaleString()}</GeneAttributeValue>
+      </GeneAttributeValues>
+    </GeneAttributes>
   )
 }
 
 RegionInfo.propTypes = {
-  regionData: PropTypes.object.isRequired,
+  region: PropTypes.shape({
+    start: PropTypes.number.isRequired,
+    stop: PropTypes.number.isRequired,
+  }).isRequired,
   variantCount: PropTypes.number.isRequired,
 }
 
-export default connect(
-  state => ({
-    regionData: regionData(state),
-    variantCount: variantCount(state)
-  })
-)(RegionInfo)
+export default connect(state => ({
+  region: regionData(state).toJS(),
+  variantCount: variantCount(state),
+}))(RegionInfo)

--- a/projects/gnomad/src/RegionPage/index.js
+++ b/projects/gnomad/src/RegionPage/index.js
@@ -1,20 +1,38 @@
+import PropTypes from 'prop-types'
 import React from 'react'
+import styled from 'styled-components'
 
 import { RegionHoc } from '@broad/region'
 import { VariantTable } from '@broad/table'
-import { GenePage, Summary, TableSection } from '@broad/ui'
+import { GenePage, TableSection } from '@broad/ui'
 
+import GnomadPageHeading from '../GnomadPageHeading'
 import Settings from '../Settings'
 import tableConfig from '../tableConfig'
 import { fetchRegion } from './fetch'
 import RegionInfo from './RegionInfo'
 import RegionViewer from './RegionViewer'
 
-const RegionPage = () => (
+/**
+ * FIXME
+ * This section previously had a 97% width left aligned div nested in a 90% width centered div.
+ * This imitates the same layout with fewer elements. The horizontal alignment of various sections
+ * needs to be made consistent.
+ */
+const RegionInfoSection = styled.div`
+  width: 87%;
+  padding-right: 3%;
+  margin-bottom: 10px;
+`
+
+const RegionPage = ({ region }) => (
   <GenePage>
-    <Summary>
-      <RegionInfo />
-    </Summary>
+    <RegionInfoSection>
+      <GnomadPageHeading>{`${region.chrom}-${region.start}-${region.stop}`}</GnomadPageHeading>
+      <div>
+        <RegionInfo />
+      </div>
+    </RegionInfoSection>
     <RegionViewer coverageStyle={'new'} />
     <TableSection>
       <Settings />
@@ -22,5 +40,13 @@ const RegionPage = () => (
     </TableSection>
   </GenePage>
 )
+
+RegionPage.propTypes = {
+  region: PropTypes.shape({
+    chrom: PropTypes.string.isRequired,
+    start: PropTypes.number.isRequired,
+    stop: PropTypes.number.isRequired,
+  }).isRequired,
+}
 
 export default RegionHoc(RegionPage, fetchRegion, 'gnomadCombinedVariants')

--- a/projects/gnomad/src/Settings.js
+++ b/projects/gnomad/src/Settings.js
@@ -1,86 +1,62 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
+import styled from 'styled-components'
 
 import { QuestionMark } from '@broad/help'
-import {
-  actions as variantActions,
-  selectedVariantDataset,
-  variantFilter,
-  variantQcFilter,
-} from '@broad/redux-variants'
-import {
-  ConsequenceCategoriesControl,
-  SettingsContainer,
-  MenusContainer,
-  SearchContainer,
-  DataSelectionGroup,
-  DataSelectionContainer,
-  Search,
-} from '@broad/ui'
+import { actions as variantActions, variantFilter, variantQcFilter } from '@broad/redux-variants'
+import { Checkbox, ConsequenceCategoriesControl, Search } from '@broad/ui'
+
+const SettingsWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+
+  @media (max-width: 900px) {
+    flex-direction: column;
+    align-items: center;
+
+    > div {
+      margin-bottom: 1.5em;
+    }
+  }
+`
 
 const GeneSettings = ({
-  selectedVariantDataset,
   searchVariants,
   setVariantFilter,
   variantFilter,
-  setSelectedVariantDataset,
   toggleVariantQcFilter,
   variantQcFilter,
 }) => (
-  <SettingsContainer>
-    <MenusContainer>
-      <DataSelectionGroup>
-        <ConsequenceCategoriesControl
-          categorySelections={variantFilter}
-          id="variant-filter"
-          onChange={setVariantFilter}
-        />
+  <SettingsWrapper>
+    <div>
+      <ConsequenceCategoriesControl
+        categorySelections={variantFilter}
+        id="variant-filter"
+        onChange={setVariantFilter}
+      />
+    </div>
 
-        <DataSelectionContainer>
-          <select
-            onChange={event => setSelectedVariantDataset(event.target.value)}
-            value={selectedVariantDataset}
-          >
-            <option value="gnomadExomeVariants">gnomAD exomes</option>
-            <option value="gnomadGenomeVariants">gnomAD genomes</option>
-            <option value="gnomadCombinedVariants">gnomAD</option>
-            <option value="exacVariants">ExAC</option>
-          </select>
-          <QuestionMark topic={'dataset-selection'} display={'inline'} />
-        </DataSelectionContainer>
-      </DataSelectionGroup>
-      <DataSelectionGroup>
-        <span>
-          <label htmlFor="qcFilter">
-            <input
-              id="qcFilter"
-              type="checkbox"
-              checked={!variantQcFilter}
-              style={{ marginRight: '5px' }}
-              onChange={toggleVariantQcFilter}
-            />
-            Include filtered variants
-          </label>
-          <QuestionMark topic={'include-filtered-variants'} display={'inline'} />
-        </span>
+    <div>
+      <Checkbox
+        checked={!variantQcFilter}
+        id="qcFilter2"
+        label="Include filtered variants"
+        onChange={toggleVariantQcFilter}
+      />
+      <QuestionMark topic="include-filtered-variants" display="inline" />
+    </div>
 
-        <SearchContainer>
-          <Search
-            placeholder={'Search variant table'}
-            onChange={searchVariants}
-            withKeyboardShortcuts
-          />
-        </SearchContainer>
-      </DataSelectionGroup>
-    </MenusContainer>
-  </SettingsContainer>
+    <div>
+      <Search placeholder="Search variant table" onChange={searchVariants} withKeyboardShortcuts />
+    </div>
+  </SettingsWrapper>
 )
 
 GeneSettings.propTypes = {
   searchVariants: PropTypes.func.isRequired,
-  selectedVariantDataset: PropTypes.string.isRequired,
-  setSelectedVariantDataset: PropTypes.func.isRequired,
   setVariantFilter: PropTypes.func.isRequired,
   toggleVariantQcFilter: PropTypes.func.isRequired,
   variantFilter: PropTypes.shape({
@@ -93,7 +69,6 @@ GeneSettings.propTypes = {
 }
 
 const mapStateToProps = state => ({
-  selectedVariantDataset: selectedVariantDataset(state),
   variantQcFilter: variantQcFilter(state),
   variantFilter: variantFilter(state),
 })
@@ -101,7 +76,6 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   setVariantFilter: filter => dispatch(variantActions.setVariantFilter(filter)),
   searchVariants: searchText => dispatch(variantActions.searchVariants(searchText)),
-  setSelectedVariantDataset: dataset => dispatch(variantActions.setSelectedVariantDataset(dataset)),
   toggleVariantQcFilter: () => dispatch(variantActions.toggleVariantQcFilter()),
 })
 


### PR DESCRIPTION
* Add dataset menu to heading on gene/region pages
* Remove dataset menu from variant filter settings
* Remove options for gnomAD exomes/genomes only
* Correct variant count on region page

Resolves #57
Relates to #164

## Gene page

### Before
<img width="1792" alt="screen shot 2018-09-18 at 9 21 42 pm" src="https://user-images.githubusercontent.com/1156625/45725402-c03d7680-bb88-11e8-9a26-4811ade6395c.png">

### After
<img width="1792" alt="screen shot 2018-09-18 at 9 18 13 pm" src="https://user-images.githubusercontent.com/1156625/45725404-c03d7680-bb88-11e8-937a-283142034909.png">
<img width="1792" alt="screen shot 2018-09-18 at 9 18 17 pm" src="https://user-images.githubusercontent.com/1156625/45725405-c03d7680-bb88-11e8-98d3-2faff6c26842.png">

## Region page

### Before
<img width="1792" alt="screen shot 2018-09-18 at 9 24 32 pm" src="https://user-images.githubusercontent.com/1156625/45725460-04c91200-bb89-11e8-8acc-97a63efa9ebd.png">

### After
<img width="1792" alt="screen shot 2018-09-18 at 9 21 05 pm" src="https://user-images.githubusercontent.com/1156625/45725413-c7648480-bb88-11e8-98a1-df7935ad7c26.png">
