### PR TITLE
Show variants on region page only for regions smaller than 10k base pairs

### DIFF
--- a/packages/api/src/schema/types/elasticVariant.js
+++ b/packages/api/src/schema/types/elasticVariant.js
@@ -541,6 +541,24 @@ export const lookupElasticVariantsByInterval = ({ elasticClient, index, dataset,
   })
 }
 
+export const countVariantsInRegion = async ({ elasticClient, index, xstart, xstop }) => {
+  const response = await elasticClient.count({
+    index,
+    type: 'variant',
+    body: {
+      query: {
+        bool: {
+          filter: {
+            range: { xpos: { gte: xstart, lte: xstop } },
+          },
+        },
+      },
+    },
+  })
+
+  return response.count
+}
+
 export const lookupElasticVariantsInRegion = async ({ elasticClient, index, xstart, xstop }) => {
   const fields = [
     'hgvsp',

--- a/packages/api/src/schema/types/exacElasticVariant.js
+++ b/packages/api/src/schema/types/exacElasticVariant.js
@@ -163,6 +163,22 @@ export const lookupElasticVariantsByGeneId = ({
   }).catch(error => console.log(error))
 }
 
+export const countExacVariantsInRegion = async ({ elasticClient, start, stop, chrom }) => {
+  const response = await elasticClient.count({
+    index: 'exacv1',
+    type: 'variant',
+    body: {
+      query: {
+        bool: {
+          filter: [{ range: { start: { gte: start, lte: stop } } }, { term: { contig: chrom } }],
+        },
+      },
+    },
+  })
+
+  return response.count
+}
+
 export const lookupElasticVariantsInRegion = async ({ elasticClient, start, stop, chrom }) => {
   const fields = [
     'hgvsp',

--- a/packages/api/src/schema/types/region.js
+++ b/packages/api/src/schema/types/region.js
@@ -23,6 +23,9 @@ import * as fromExacVariant from './exacElasticVariant'
 
 import geneType, { lookupGenesByInterval } from './gene'
 
+// Individual variants can only be returned for regions smaller than this
+const FETCH_VARIANTS_REGION_SIZE_LIMIT = 10000
+
 const regionType = new GraphQLObjectType({
   name: 'Region',
   fields: () => ({
@@ -100,72 +103,53 @@ const regionType = new GraphQLObjectType({
     gnomadExomeVariants: {
       type: new GraphQLList(elasticVariantType),
       resolve: (obj, args, ctx) => {
-        console.log(obj.regionSize)
-        if (obj.regionSize < 10000) {
-          return lookupElasticVariantsInRegion({
-            elasticClient: ctx.database.elastic,
-            index: 'gnomad_exomes_202_37',
-            dataset: 'exomes',
-            xstart: obj.xstart,
-            xstop: obj.xstop,
-            numberOfVariants: 5000,
-          })
+        if (obj.regionSize > FETCH_VARIANTS_REGION_SIZE_LIMIT) {
+          throw Error(
+            `Variants can only be returned by for regions smaller than ${FETCH_VARIANTS_REGION_SIZE_LIMIT} base pairs`
+          )
         }
+
         return lookupElasticVariantsInRegion({
           elasticClient: ctx.database.elastic,
           index: 'gnomad_exomes_202_37',
-          dataset: 'exomes',
           xstart: obj.xstart,
           xstop: obj.xstop,
-          numberOfVariants: 5000,
         })
-      }
+      },
     },
     gnomadGenomeVariants: {
       type: new GraphQLList(elasticVariantType),
       resolve: (obj, args, ctx) => {
-        console.log(obj.regionSize)
-        if (obj.regionSize < 10000) {
-          return lookupElasticVariantsInRegion({
-            elasticClient: ctx.database.elastic,
-            index: 'gnomad_genomes_202_37',
-            dataset: 'genomes',
-            xstart: obj.xstart,
-            xstop: obj.xstop,
-            numberOfVariants: 5000,
-          })
+        if (obj.regionSize > FETCH_VARIANTS_REGION_SIZE_LIMIT) {
+          throw Error(
+            `Variants can only be returned by for regions smaller than ${FETCH_VARIANTS_REGION_SIZE_LIMIT} base pairs`
+          )
         }
+
         return lookupElasticVariantsInRegion({
           elasticClient: ctx.database.elastic,
           index: 'gnomad_genomes_202_37',
-          dataset: 'genomes',
           xstart: obj.xstart,
           xstop: obj.xstop,
-          numberOfVariants: 5000,
         })
-      }
+      },
     },
     exacVariants: {
       type: new GraphQLList(elasticVariantType),
       resolve: (obj, args, ctx) => {
-        console.log(obj.regionSize)
-        if (obj.regionSize < 10000) {
-          return fromExacVariant.lookupElasticVariantsInRegion({
-            elasticClient: ctx.database.elastic,
-            start: obj.start,
-            stop: obj.stop,
-            chrom: obj.chrom,
-            numberOfVariants: 5000,
-          })
+        if (obj.regionSize > FETCH_VARIANTS_REGION_SIZE_LIMIT) {
+          throw Error(
+            `Variants can only be returned by for regions smaller than ${FETCH_VARIANTS_REGION_SIZE_LIMIT} base pairs`
+          )
         }
+
         return fromExacVariant.lookupElasticVariantsInRegion({
           elasticClient: ctx.database.elastic,
           start: obj.start,
           stop: obj.stop,
           chrom: obj.chrom,
-          numberOfVariants: 5000,
         })
-      }
+      },
     },
   }),
 })

--- a/packages/redux-variants/variants.js
+++ b/packages/redux-variants/variants.js
@@ -290,7 +290,7 @@ export default function createVariantReducer({
     [regionTypes.RECEIVE_REGION_DATA] (state, { regionData }) {
       return datasetKeys.reduce((nextState, datasetKey) => {
         let variantMap = {}
-        if (variantDatasets[datasetKey]) {
+        if (regionData.get(datasetKey) && variantDatasets[datasetKey]) {
           regionData.get(datasetKey).forEach((variant) => {
             variantMap[variant.get('variant_id')] = new variantRecords[datasetKey](
               variant

--- a/packages/region/src/RegionHoc.js
+++ b/packages/region/src/RegionHoc.js
@@ -17,6 +17,7 @@ const RegionPageContainer = ComposedComponent => class RegionPage extends Compon
   state = {
     isLoading: false,
     loadError: null,
+    queryErrors: null,
     regionData: null,
   }
 
@@ -37,12 +38,14 @@ const RegionPageContainer = ComposedComponent => class RegionPage extends Compon
 
     this.props.fetchRegionData(this.props.regionId)
       .then(
-        (regionData) => {
+        response => {
+          const regionData = response.data.region
           if (!this.mounted) {
             return
           }
           this.setState({
             isLoading: false,
+            queryErrors: response.errors,
             regionData,
           })
         },
@@ -72,9 +75,7 @@ const RegionPageContainer = ComposedComponent => class RegionPage extends Compon
     }
 
     if (this.state.regionData) {
-      return (
-        <ComposedComponent region={this.state.regionData} />
-      )
+      return <ComposedComponent errors={this.state.queryErrors} region={this.state.regionData} />
     }
 
     return null
@@ -96,7 +97,8 @@ export const RegionHoc = (
 
         thunkDispatch(regionActions.requestRegionData(regionId))
         return regionFetchFunction(regionId)
-          .then((regionData) => {
+          .then(response => {
+            const regionData = response.data.region
             thunkDispatch(regionActions.receiveRegionData(regionId, regionData))
 
             let defaultVariantFilter = {
@@ -118,7 +120,7 @@ export const RegionHoc = (
             thunkDispatch(variantActions.searchVariants(''))
             thunkDispatch(variantActions.setVariantFilter(defaultVariantFilter))
 
-            return regionData
+            return response
           })
       })
     }

--- a/packages/region/src/RegionHoc.js
+++ b/packages/region/src/RegionHoc.js
@@ -101,24 +101,16 @@ export const RegionHoc = (
             const regionData = response.data.region
             thunkDispatch(regionActions.receiveRegionData(regionId, regionData))
 
-            let defaultVariantFilter = {
-              lof: true,
-              missense: true,
-              synonymous: true,
-              other: true,
-            }
-            if (regionData.stop - regionData.start > 50000) {
-              defaultVariantFilter = {
-                lof: true,
-                missense: false,
-                synonymous: false,
-                other: false,
-              }
-            }
-
             // Reset variant filters when loading a new region
             thunkDispatch(variantActions.searchVariants(''))
-            thunkDispatch(variantActions.setVariantFilter(defaultVariantFilter))
+            thunkDispatch(
+              variantActions.setVariantFilter({
+                lof: true,
+                missense: true,
+                synonymous: true,
+                other: true,
+              })
+            )
 
             return response
           })

--- a/projects/gnomad/src/RegionPage/RegionInfo.js
+++ b/projects/gnomad/src/RegionPage/RegionInfo.js
@@ -13,17 +13,17 @@ import {
   GeneAttributeValue,
 } from '@broad/ui'
 
-const RegionInfo = ({ region, variantCount }) => {
+const RegionInfo = ({ region, showVariants, variantCount }) => {
   const { start, stop } = region
   return (
     <GeneAttributes>
       <GeneAttributeKeys>
         <GeneAttributeKey>Region size</GeneAttributeKey>
-        <GeneAttributeKey>Total variants</GeneAttributeKey>
+        {showVariants && <GeneAttributeKey>Total variants</GeneAttributeKey>}
       </GeneAttributeKeys>
       <GeneAttributeValues>
         <GeneAttributeValue>{(stop - start).toLocaleString()} BP</GeneAttributeValue>
-        <GeneAttributeValue>{variantCount.toLocaleString()}</GeneAttributeValue>
+        {showVariants && <GeneAttributeValue>{variantCount.toLocaleString()}</GeneAttributeValue>}
       </GeneAttributeValues>
     </GeneAttributes>
   )
@@ -34,6 +34,7 @@ RegionInfo.propTypes = {
     start: PropTypes.number.isRequired,
     stop: PropTypes.number.isRequired,
   }).isRequired,
+  showVariants: PropTypes.bool.isRequired,
   variantCount: PropTypes.number.isRequired,
 }
 

--- a/projects/gnomad/src/RegionPage/RegionViewer.js
+++ b/projects/gnomad/src/RegionPage/RegionViewer.js
@@ -59,6 +59,7 @@ const RegionViewerConnected = ({
   ]
 
   const totalBp = stop - start
+  const showVariants = totalBp <= 10000
 
   const smallScreen = screenSize.width < 900
   const regionViewerWidth = smallScreen ? screenSize.width - 150 : screenSize.width - 300
@@ -94,12 +95,14 @@ const RegionViewerConnected = ({
           onGeneClick={geneName => history.push(`/gene/${geneName}`)}
         />
 
-        <VariantAlleleFrequencyTrack
-          title={`${datasetTranslations[selectedVariantDataset]}\n(${allVariants.size})`}
-          variants={variantsReversed.toJS()}
-        />
+        {showVariants && (
+          <VariantAlleleFrequencyTrack
+            title={`${datasetTranslations[selectedVariantDataset]}\n(${allVariants.size})`}
+            variants={variantsReversed.toJS()}
+          />
+        )}
 
-        <NavigatorTrackConnected title={'Viewing in table'} />
+        {showVariants && <NavigatorTrackConnected title="Viewing in table" />}
       </RegionViewer>
     </div>
   )

--- a/projects/gnomad/src/RegionPage/RegionViewer.js
+++ b/projects/gnomad/src/RegionPage/RegionViewer.js
@@ -26,6 +26,7 @@ const RegionViewerConnected = ({
   history,
   selectedVariantDataset,
   screenSize,
+  showVariants,
 }) => {
   const {
     chrom,
@@ -59,7 +60,6 @@ const RegionViewerConnected = ({
   ]
 
   const totalBp = stop - start
-  const showVariants = totalBp <= 10000
 
   const smallScreen = screenSize.width < 900
   const regionViewerWidth = smallScreen ? screenSize.width - 150 : screenSize.width - 300
@@ -113,6 +113,7 @@ RegionViewerConnected.propTypes = {
   history: PropTypes.object.isRequired,
   selectedVariantDataset: PropTypes.string.isRequired,
   screenSize: PropTypes.object.isRequired,
+  showVariants: PropTypes.bool.isRequired,
 }
 RegionViewerConnected.defaultProps = {
   coverageStyle: null,

--- a/projects/gnomad/src/RegionPage/fetch.js
+++ b/projects/gnomad/src/RegionPage/fetch.js
@@ -1,60 +1,7 @@
 import fetch from 'graphql-fetch'
 
-const variantsQuery = `
-gnomadGenomeVariants {
-  variant_id
-  rsid
-  pos
-  xpos
-  hgvsc
-  hgvsp
-  allele_count
-  allele_freq
-  allele_num
-  filters
-  hom_count
-  consequence
-  lof
-  lcr
-  segdup
-}
-gnomadExomeVariants {
-  variant_id
-  rsid
-  pos
-  xpos
-  hgvsc
-  hgvsp
-  allele_count
-  allele_freq
-  allele_num
-  filters
-  hom_count
-  consequence
-  lof
-  lcr
-  segdup
-}
-exacVariants {
-  variant_id
-  rsid
-  pos
-  xpos
-  hgvsc
-  hgvsp
-  allele_count
-  allele_freq
-  allele_num
-  filters
-  hom_count
-  consequence
-  lof
-}
-`
-
 export const fetchRegion = regionId => {
   const [chrom, start, stop] = regionId.split('-')
-  const regionSize = Number(stop) - Number(start)
   const query = `{
   region(start: ${start}, stop: ${stop}, chrom: "${chrom}") {
     start
@@ -101,11 +48,59 @@ export const fetchRegion = regionId => {
       pos
       mean
     }
-    ${regionSize <= 10000 ? variantsQuery : ''}
+    gnomadGenomeVariants {
+      variant_id
+      rsid
+      pos
+      xpos
+      hgvsc
+      hgvsp
+      allele_count
+      allele_freq
+      allele_num
+      filters
+      hom_count
+      consequence
+      lof
+      lcr
+      segdup
+    }
+    gnomadExomeVariants {
+      variant_id
+      rsid
+      pos
+      xpos
+      hgvsc
+      hgvsp
+      allele_count
+      allele_freq
+      allele_num
+      filters
+      hom_count
+      consequence
+      lof
+      lcr
+      segdup
+    }
+    exacVariants {
+      variant_id
+      rsid
+      pos
+      xpos
+      hgvsc
+      hgvsp
+      allele_count
+      allele_freq
+      allele_num
+      filters
+      hom_count
+      consequence
+      lof
+    }
   }
 
 }
 `
 
-  return fetch(process.env.GNOMAD_API_URL)(query).then(data => data.data.region)
+  return fetch(process.env.GNOMAD_API_URL)(query)
 }

--- a/projects/gnomad/src/RegionPage/fetch.js
+++ b/projects/gnomad/src/RegionPage/fetch.js
@@ -1,9 +1,62 @@
 import fetch from 'graphql-fetch'
 
+const variantsQuery = `
+gnomadGenomeVariants {
+  variant_id
+  rsid
+  pos
+  xpos
+  hgvsc
+  hgvsp
+  allele_count
+  allele_freq
+  allele_num
+  filters
+  hom_count
+  consequence
+  lof
+  lcr
+  segdup
+}
+gnomadExomeVariants {
+  variant_id
+  rsid
+  pos
+  xpos
+  hgvsc
+  hgvsp
+  allele_count
+  allele_freq
+  allele_num
+  filters
+  hom_count
+  consequence
+  lof
+  lcr
+  segdup
+}
+exacVariants {
+  variant_id
+  rsid
+  pos
+  xpos
+  hgvsc
+  hgvsp
+  allele_count
+  allele_freq
+  allele_num
+  filters
+  hom_count
+  consequence
+  lof
+}
+`
+
 export const fetchRegion = regionId => {
   const [chrom, start, stop] = regionId.split('-')
+  const regionSize = Number(stop) - Number(start)
   const query = `{
-  region(start: ${Number(start)}, stop: ${Number(stop)}, chrom: "${chrom}") {
+  region(start: ${start}, stop: ${stop}, chrom: "${chrom}") {
     start
     stop
     xstop
@@ -48,55 +101,7 @@ export const fetchRegion = regionId => {
       pos
       mean
     }
-    gnomadGenomeVariants {
-      variant_id
-      rsid
-      pos
-      xpos
-      hgvsc
-      hgvsp
-      allele_count
-      allele_freq
-      allele_num
-      filters
-      hom_count
-      consequence
-      lof
-      lcr
-      segdup
-    }
-    gnomadExomeVariants {
-      variant_id
-      rsid
-      pos
-      xpos
-      hgvsc
-      hgvsp
-      allele_count
-      allele_freq
-      allele_num
-      filters
-      hom_count
-      consequence
-      lof
-      lcr
-      segdup
-    }
-    exacVariants {
-      variant_id
-      rsid
-      pos
-      xpos
-      hgvsc
-      hgvsp
-      allele_count
-      allele_freq
-      allele_num
-      filters
-      hom_count
-      consequence
-      lof
-    }
+    ${regionSize <= 10000 ? variantsQuery : ''}
   }
 
 }

--- a/projects/gnomad/src/RegionPage/index.js
+++ b/projects/gnomad/src/RegionPage/index.js
@@ -34,10 +34,14 @@ const RegionPage = ({ region }) => (
       </div>
     </RegionInfoSection>
     <RegionViewer coverageStyle={'new'} />
-    <TableSection>
-      <Settings />
-      <VariantTable tableConfig={tableConfig} />
-    </TableSection>
+    {region.stop - region.start <= 10000 ? (
+      <TableSection>
+        <Settings />
+        <VariantTable tableConfig={tableConfig} />
+      </TableSection>
+    ) : (
+      <p>To view variants, select a region smaller than 10,000 base pairs</p>
+    )}
   </GenePage>
 )
 


### PR DESCRIPTION
Since the browser currently fetches all variants in the selected gene or region. However, there is a limit to how many can be loaded without degrading performance. Previously, the region page would only fetch the first 5000 variants (by position) from each of gnomAD exomes/genomes without any indication that the variant list was incomplete.

This change clarifies the limit. For regions containing > 30k variants, the region page does not fetch individual variants or show the variant tracks or table (replacing them with a message "This region has too many variants to display. To view individual variants, select a smaller region". The coverage and genes tracks are still available for regions with a large number of variants.

The limit isn't exact for gnomAD because it rejects any region than contains more than 30k variants in gnomAD exomes or 30k variants in gnomAD genomes. So a region than contains fewer than 30k in each of those, but more than 30k in the two combined (due to variants that don't overlap) is possible. This should be resolved with #162.

Resolves #234 