### PR TITLE
Include LCR and Segdup flags in region query

### DIFF
--- a/projects/gnomad/src/RegionPage/fetch.js
+++ b/projects/gnomad/src/RegionPage/fetch.js
@@ -80,6 +80,8 @@ export const fetchRegion = (regionId, url = API_URL) => {
       hom_count
       consequence
       lof
+      lcr
+      segdup
     }
     gnomadExomeVariants {
       variant_id
@@ -95,6 +97,8 @@ export const fetchRegion = (regionId, url = API_URL) => {
       hom_count
       consequence
       lof
+      lcr
+      segdup
     }
     exacVariants {
       variant_id


### PR DESCRIPTION
Currently, the region page never displays LCR or Segdup flags for any variant because it does not include them in its GraphQL query.

Resolves #236 