### PR TITLE
Do not modify case numbers in exome results browsers

### DIFF
--- a/projects/exome-results-browsers/src/client/GenePage/RegionViewer.js
+++ b/projects/exome-results-browsers/src/client/GenePage/RegionViewer.js
@@ -55,13 +55,6 @@ class GeneViewer extends PureComponent {
     }
 
     const cases = variantsReversed
-      .map(v => {
-        if (v.ac_denovo) {
-          const cases = v.ac_case ? v.ac_case : 0
-          return v.set('ac_case', v.ac_denovo + cases).set('an_case', 46846) // HACK
-        }
-        return v
-      })
       .filter(v => v.ac_case > 0)
       .map(v => v.set('allele_freq', v.af_case))
 


### PR DESCRIPTION
This code was copied over from the SCHEMA browser

https://github.com/macarthur-lab/gnomadjs/blob/69ce4177c7e3050c97f1c8ac2477ca430f60c595/projects/schizophrenia/src/ExomePage/RegionViewer.js#L85-L93

It may have been acceptable for a demo of a draft SCHEMA dataset, but the browser should not be modifying data. Also, this code is shared among all exome results browsers and the hard coded case AN here is only applicable to SCHEMA