### PR TITLE
Add tooltips to variant flags

### DIFF
--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -10,6 +10,7 @@
     "@broad/redux-genes": "*",
     "@broad/redux-variants": "*",
     "@broad/region": "*",
+    "@broad/ui": "*",
     "@broad/utilities": "*",
     "immutable": "^3.8.1",
     "keymirror": "^0.1.1",

--- a/packages/table/src/Table.js
+++ b/packages/table/src/Table.js
@@ -10,6 +10,7 @@ import { withSize } from 'react-sizeme'
 import { InfiniteLoader, List } from 'react-virtualized'
 import styled from 'styled-components'
 
+import { Badge } from '@broad/ui'
 import { getCategoryFromConsequence, getLabelForConsequenceTerm } from '@broad/utilities'
 
 const abstractCellStyle = {
@@ -113,35 +114,30 @@ const formatDatasets = (dataRow, index) => dataRow.datasets.valueSeq().toJS().ma
   )
 })
 
-const flagConfig = {
-  lcr: { color: 'gray', abbreviation: 'LCR', border: '1px solid #000' },
-  segdup: { color: 'gray', abbreviation: 'SEGDUP', border: '1px solid #000' },
-  lof: { color: '#d9534f', abbreviation: 'LC LoF', border: '1px solid #000' },
-
+const flagProps = {
+  lcr: {
+    children: 'LCR',
+    level: 'info',
+    tooltip: 'Found in a low complexity region\nVariant annotation or quality dubious',
+  },
+  segdup: {
+    children: 'SEGDUP',
+    level: 'info',
+    tooltip: 'Found in a segmental duplication region\nVariant annotation or quality dubious',
+  },
+  lof: {
+    children: 'LC LoF',
+    level: 'error',
+    tooltip: 'Low-confidence LoF\nVariant annotation or quality dubious',
+  },
 }
 
 const formatFlags = (dataRow, index) => {
-  return ['lcr', 'segdup', 'lof']
-    .filter((flag) => {
-      return dataRow.get(flag) === true || dataRow.get(flag) === 'LC'
-    })
-    .map((flag) => {
-      return (
-        <span
-          key={`${flag}${index}`}
-          style={{
-            border: flagConfig[flag].border,
-            borderRadius: 3,
-            color: 'white',
-            marginLeft: 10,
-            padding: '1px 4px 1px 4px',
-            backgroundColor: flagConfig[flag].color,
-          }}
-        >
-          {flagConfig[flag].abbreviation}
-        </span>
-      )
-    })
+  const variantFlags = ['lcr', 'segdup', 'lof'].filter(
+    flag => dataRow.get(flag) === true || dataRow.get(flag) === 'LC'
+  )
+
+  return variantFlags.map(flag => <Badge key={flag} {...flagProps[flag]} />)
 }
 
 const formatFitler = (filters, index) => filters.map(filter => (

--- a/packages/ui/src/Badge.js
+++ b/packages/ui/src/Badge.js
@@ -4,7 +4,13 @@ import styled from 'styled-components'
 
 import { TooltipAnchor } from './tooltip/TooltipAnchor'
 
-const TextTooltip = ({ text }) => <span>{text}</span>
+const TextTooltipWrapper = styled.span`
+  line-height: 1.5;
+  text-align: center;
+  white-space: pre-line;
+`
+
+const TextTooltip = ({ text }) => <TextTooltipWrapper>{text}</TextTooltipWrapper>
 
 TextTooltip.propTypes = {
   text: PropTypes.string.isRequired,


### PR DESCRIPTION
![screen shot 2018-10-04 at 4 53 10 pm](https://user-images.githubusercontent.com/1156625/46502456-2d424480-c7f6-11e8-8070-7e3640069cb7.png)

Tooltip text taken from 
https://github.com/macarthur-lab/gnomad_browser/blob/b4ff2705fd540037acc31f234f660b26162f5207/templates/variant_table_template.html#L140
and
https://github.com/macarthur-lab/gnomad_browser/blob/b4ff2705fd540037acc31f234f660b26162f5207/templates/variant.html#L189-L191

Resolves #262