### PR TITLE
Add API for accessing updated ExAC data

### DIFF
--- a/packages/api/src/schema/datasets/datasetsConfig.js
+++ b/packages/api/src/schema/datasets/datasetsConfig.js
@@ -1,12 +1,20 @@
 import ExacVariantDetailsType from './exac/ExacVariantDetailsType'
+import countExacVariantsInRegion from './exac/countExacVariantsInRegion'
 import fetchExacVariantDetails from './exac/fetchExacVariantDetails'
+import fetchExacVariantsByGene from './exac/fetchExacVariantsByGene'
+import fetchExacVariantsByRegion from './exac/fetchExacVariantsByRegion'
+import fetchExacVariantsByTranscript from './exac/fetchExacVariantsByTranscript'
 
 import GnomadVariantDetailsType from './gnomad/GnomadVariantDetailsType'
 import fetchGnomadVariantDetails from './gnomad/fetchGnomadVariantDetails'
 
 const datasetsConfig = {
   exac: {
+    countVariantsInRegion: countExacVariantsInRegion,
     fetchVariantDetails: fetchExacVariantDetails,
+    fetchVariantsByGene: fetchExacVariantsByGene,
+    fetchVariantsByRegion: fetchExacVariantsByRegion,
+    fetchVariantsByTranscript: fetchExacVariantsByTranscript,
     variantDetailsType: ExacVariantDetailsType,
   },
   gnomad: {

--- a/packages/api/src/schema/datasets/exac/ExacVariantDetailsType.js
+++ b/packages/api/src/schema/datasets/exac/ExacVariantDetailsType.js
@@ -30,6 +30,8 @@ const ExacVariantDetailsType = new GraphQLObjectType({
         fields: {
           raw: { type: GraphQLInt },
           adj: { type: GraphQLInt },
+          hemi: { type: GraphQLInt },
+          hom: { type: GraphQLInt },
         },
       }),
     },
@@ -43,6 +45,7 @@ const ExacVariantDetailsType = new GraphQLObjectType({
       }),
     },
     filters: { type: new GraphQLList(GraphQLString) },
+    flags: { type: new GraphQLList(GraphQLString) },
     populations: { type: new GraphQLList(PopulationType) },
     qualityMetrics: { type: VariantQualityMetricsType },
     rsid: { type: GraphQLString },

--- a/packages/api/src/schema/datasets/exac/countExacVariantsInRegion.js
+++ b/packages/api/src/schema/datasets/exac/countExacVariantsInRegion.js
@@ -1,0 +1,27 @@
+const countExacVariantsByRegion = async (ctx, { chrom, start, stop }) => {
+  const padding = 75
+  const rangeQuery = {
+    range: {
+      pos: {
+        gte: start - padding,
+        lte: stop + padding,
+      },
+    },
+  }
+
+  const response = await ctx.database.elastic.count({
+    index: 'exac_v1_variants',
+    type: 'variant',
+    body: {
+      query: {
+        bool: {
+          filter: [{ term: { chrom } }, rangeQuery],
+        },
+      },
+    },
+  })
+
+  return response.count
+}
+
+export default countExacVariantsByRegion

--- a/packages/api/src/schema/datasets/exac/fetchExacVariantsByGene.js
+++ b/packages/api/src/schema/datasets/exac/fetchExacVariantsByGene.js
@@ -1,0 +1,98 @@
+import { fetchAllSearchResults } from '../../../utilities/elasticsearch'
+import { lookupExonsByTranscriptId } from '../../types/exon'
+
+const fetchExacVariantsByGene = async (ctx, geneId, canonicalTranscriptId) => {
+  const geneExons = await lookupExonsByTranscriptId(ctx.database.gnomad, canonicalTranscriptId)
+  const filteredRegions = geneExons.filter(exon => exon.feature_type === 'CDS')
+  const padding = 75
+  const rangeQueries = filteredRegions.map(region => ({
+    range: {
+      pos: {
+        gte: region.start - padding,
+        lte: region.stop + padding,
+      },
+    },
+  }))
+
+  const hits = await fetchAllSearchResults(ctx.database.elastic, {
+    index: 'exac_v1_variants',
+    type: 'variant',
+    size: 10000,
+    _source: [
+      'AC_Adj',
+      'AC_Hemi',
+      'AC_Hom',
+      'AN_Adj',
+      'alt',
+      'chrom',
+      'filters',
+      'flags',
+      'pos',
+      'ref',
+      'rsid',
+      'variant_id',
+      'xpos',
+    ],
+
+    body: {
+      script_fields: {
+        csq: {
+          script: {
+            lang: 'painless',
+            inline:
+              'params._source.sortedTranscriptConsequences.find(c -> c.gene_id == params.geneId)',
+            params: {
+              geneId,
+            },
+          },
+        },
+      },
+      query: {
+        bool: {
+          filter: [
+            {
+              nested: {
+                path: 'sortedTranscriptConsequences',
+                query: {
+                  term: { 'sortedTranscriptConsequences.gene_id': geneId },
+                },
+              },
+            },
+            { bool: { should: rangeQueries } },
+          ],
+        },
+      },
+      sort: [{ pos: { order: 'asc' } }],
+    },
+  })
+
+  return hits.map(hit => {
+    // eslint-disable-next-line no-underscore-dangle
+    const variantData = hit._source
+    return {
+      gqlType: 'VariantSummary',
+      // variant interface fields
+      alt: variantData.alt,
+      chrom: variantData.chrom,
+      pos: variantData.pos,
+      ref: variantData.ref,
+      variantId: variantData.variant_id,
+      xpos: variantData.xpos,
+      // other fields
+      ac: variantData.AC_Adj,
+      ac_hemi: variantData.AC_Hemi,
+      ac_hom: variantData.AC_Hom,
+      af: variantData.AN_Adj === 0 ? 0 : variantData.AC_Adj / variantData.AN_Adj,
+      an: variantData.AN_Adj,
+      consequence: hit.fields.csq[0].major_consequence,
+      filters: variantData.filters,
+      flags: ['lc_lof', 'lof_flag'].filter(flag => variantData.flags[flag]),
+      hgvs: hit.fields.csq[0].hgvs,
+      hgvc: hit.fields.csq[0].hgvsc,
+      hgvp: hit.fields.csq[0].hgvsp,
+      rsid: variantData.rsid,
+    }
+  })
+}
+
+export default fetchExacVariantsByGene

--- a/packages/api/src/schema/datasets/exac/fetchExacVariantsByRegion.js
+++ b/packages/api/src/schema/datasets/exac/fetchExacVariantsByRegion.js
@@ -1,0 +1,77 @@
+import { fetchAllSearchResults } from '../../../utilities/elasticsearch'
+
+const fetchExacVariantsByRegion = async (ctx, { chrom, start, stop }) => {
+  const padding = 75
+  const rangeQuery = {
+    range: {
+      pos: {
+        gte: start - padding,
+        lte: stop + padding,
+      },
+    },
+  }
+
+  const hits = await fetchAllSearchResults(ctx.database.elastic, {
+    index: 'exac_v1_variants',
+    type: 'variant',
+    size: 10000,
+    _source: [
+      'AC_Adj',
+      'AC_Hemi',
+      'AC_Hom',
+      'AN_Adj',
+      'alt',
+      'chrom',
+      'filters',
+      'flags',
+      'main_transcript.hgvs',
+      'main_transcript.hgvsc',
+      'main_transcript.hgvsp',
+      'main_transcript.major_consequence',
+      'pos',
+      'ref',
+      'rsid',
+      'variant_id',
+      'xpos',
+    ],
+
+    body: {
+      query: {
+        bool: {
+          filter: [{ term: { chrom } }, rangeQuery],
+        },
+      },
+      sort: [{ pos: { order: 'asc' } }],
+    },
+  })
+
+  return hits.map(hit => {
+    // eslint-disable-next-line no-underscore-dangle
+    const variantData = hit._source
+    return {
+      gqlType: 'VariantSummary',
+      // variant interface fields
+      alt: variantData.alt,
+      chrom: variantData.chrom,
+      pos: variantData.pos,
+      ref: variantData.ref,
+      variantId: variantData.variant_id,
+      xpos: variantData.xpos,
+      // other fields
+      ac: variantData.AC_Adj,
+      ac_hemi: variantData.AC_Hemi,
+      ac_hom: variantData.AC_Hom,
+      af: variantData.AN_Adj === 0 ? 0 : variantData.AC_Adj / variantData.AN_Adj,
+      an: variantData.AN_Adj,
+      consequence: variantData.main_transcript.major_consequence,
+      filters: variantData.filters,
+      flags: ['lc_lof', 'lof_flag'].filter(flag => variantData.flags[flag]),
+      hgvs: variantData.main_transcript.hgvs,
+      hgvc: variantData.main_transcript.hgvsc,
+      hgvp: variantData.main_transcript.hgvsp,
+      rsid: variantData.rsid,
+    }
+  })
+}
+
+export default fetchExacVariantsByRegion

--- a/packages/api/src/schema/datasets/exac/fetchExacVariantsByTranscript.js
+++ b/packages/api/src/schema/datasets/exac/fetchExacVariantsByTranscript.js
@@ -1,0 +1,98 @@
+import { fetchAllSearchResults } from '../../../utilities/elasticsearch'
+import { lookupExonsByTranscriptId } from '../../types/exon'
+
+const fetchExacVariantsByTranscript = async (ctx, transcriptId) => {
+  const geneExons = await lookupExonsByTranscriptId(ctx.database.gnomad, transcriptId)
+  const filteredRegions = geneExons.filter(exon => exon.feature_type === 'CDS')
+  const padding = 75
+  const rangeQueries = filteredRegions.map(region => ({
+    range: {
+      pos: {
+        gte: region.start - padding,
+        lte: region.stop + padding,
+      },
+    },
+  }))
+
+  const hits = await fetchAllSearchResults(ctx.database.elastic, {
+    index: 'exac_v1_variants',
+    type: 'variant',
+    size: 10000,
+    _source: [
+      'AC_Adj',
+      'AC_Hemi',
+      'AC_Hom',
+      'AN_Adj',
+      'alt',
+      'chrom',
+      'filters',
+      'flags',
+      'pos',
+      'ref',
+      'rsid',
+      'variant_id',
+      'xpos',
+    ],
+
+    body: {
+      script_fields: {
+        csq: {
+          script: {
+            lang: 'painless',
+            inline:
+              'params._source.sortedTranscriptConsequences.find(c -> c.transcript_id == params.transcriptId)',
+            params: {
+              transcriptId,
+            },
+          },
+        },
+      },
+      query: {
+        bool: {
+          filter: [
+            {
+              nested: {
+                path: 'sortedTranscriptConsequences',
+                query: {
+                  term: { 'sortedTranscriptConsequences.transcript_id': transcriptId },
+                },
+              },
+            },
+            { bool: { should: rangeQueries } },
+          ],
+        },
+      },
+      sort: [{ pos: { order: 'asc' } }],
+    },
+  })
+
+  return hits.map(hit => {
+    // eslint-disable-next-line no-underscore-dangle
+    const variantData = hit._source
+    return {
+      gqlType: 'VariantSummary',
+      // variant interface fields
+      alt: variantData.alt,
+      chrom: variantData.chrom,
+      pos: variantData.pos,
+      ref: variantData.ref,
+      variantId: variantData.variant_id,
+      xpos: variantData.xpos,
+      // other fields
+      ac: variantData.AC_Adj,
+      ac_hemi: variantData.AC_Hemi,
+      ac_hom: variantData.AC_Hom,
+      af: variantData.AN_Adj === 0 ? 0 : variantData.AC_Adj / variantData.AN_Adj,
+      an: variantData.AN_Adj,
+      consequence: hit.fields.csq[0].major_consequence,
+      filters: variantData.filters,
+      flags: ['lc_lof', 'lof_flag'].filter(flag => variantData.flags[flag]),
+      hgvs: hit.fields.csq[0].hgvs,
+      hgvc: hit.fields.csq[0].hgvsc,
+      hgvp: hit.fields.csq[0].hgvsp,
+      rsid: variantData.rsid,
+    }
+  })
+}
+
+export default fetchExacVariantsByTranscript

--- a/packages/api/src/schema/types/gene.js
+++ b/packages/api/src/schema/types/gene.js
@@ -8,6 +8,9 @@ import {
   GraphQLFloat,
 } from 'graphql'
 
+import { datasetArgumentTypeForMethod } from '../datasets/datasetArgumentTypes'
+import datasetsConfig from '../datasets/datasetsConfig'
+
 import {
   ClinvarVariantType,
   fetchClinvarVariantsInGene,
@@ -22,6 +25,8 @@ import elasticVariantType, { lookupElasticVariantsByGeneId } from './elasticVari
 import * as fromExacVariant from './exacElasticVariant'
 
 import * as fromRegionalConstraint from './regionalConstraint'
+
+import { VariantSummaryType } from './variant'
 
 const geneType = new GraphQLObjectType({
   name: 'Gene',
@@ -147,6 +152,16 @@ const geneType = new GraphQLObjectType({
         elasticClient: ctx.database.elastic,
         geneName: obj.gene_name,
       }),
+    },
+    variants: {
+      type: new GraphQLList(VariantSummaryType),
+      args: {
+        dataset: { type: datasetArgumentTypeForMethod('fetchVariantsByGene') },
+      },
+      resolve: (obj, args, ctx) => {
+        const fetchVariantsByGene = datasetsConfig[args.dataset].fetchVariantsByGene
+        return fetchVariantsByGene(ctx, obj.gene_id, obj.canonical_transcript)
+      },
     },
   }),
 })

--- a/packages/api/src/schema/types/variant.js
+++ b/packages/api/src/schema/types/variant.js
@@ -2,10 +2,11 @@ import {
   GraphQLFloat,
   GraphQLInt,
   GraphQLInterfaceType,
+  GraphQLList,
   GraphQLNonNull,
+  GraphQLObjectType,
   GraphQLString,
 } from 'graphql'
-
 
 export const VariantInterface = new GraphQLInterfaceType({
   name: 'Variant',
@@ -17,4 +18,32 @@ export const VariantInterface = new GraphQLInterfaceType({
     variantId: { type: new GraphQLNonNull(GraphQLString) },
     xpos: { type: new GraphQLNonNull(GraphQLFloat) },
   },
+})
+
+export const VariantSummaryType = new GraphQLObjectType({
+  name: 'VariantSummary',
+  interfaces: [VariantInterface],
+  fields: {
+    // variant interface fields
+    alt: { type: new GraphQLNonNull(GraphQLString) },
+    chrom: { type: new GraphQLNonNull(GraphQLString) },
+    pos: { type: new GraphQLNonNull(GraphQLInt) },
+    ref: { type: new GraphQLNonNull(GraphQLString) },
+    variantId: { type: new GraphQLNonNull(GraphQLString) },
+    xpos: { type: new GraphQLNonNull(GraphQLFloat) },
+    // other fields
+    ac: { type: GraphQLInt },
+    ac_hemi: { type: GraphQLInt },
+    ac_hom: { type: GraphQLInt },
+    an: { type: GraphQLInt },
+    af: { type: GraphQLFloat },
+    consequence: { type: GraphQLString },
+    filters: { type: new GraphQLList(GraphQLString) },
+    flags: { type: new GraphQLList(GraphQLString) },
+    hgvs: { type: GraphQLString },
+    hgvc: { type: GraphQLString },
+    hgvp: { type: GraphQLString },
+    rsid: { type: GraphQLString },
+  },
+  isTypeOf: variantData => variantData.gqlType === 'VariantSummary',
 })


### PR DESCRIPTION
API to access the new ExAC Elasticsearch index that has fields split for multiallelic variants, flags calculated, and sortedTranscriptConsequences stored as nested objects. The browser still uses the current ExAC index since there was a bug in the code used to calculate flags. Once that is fixed and ExAC data reloaded, we can point the browser at this new API.

This returns AC/AN/AF numbers consistent with the ExAC browser (#258) and has fields split correctly for multiallelic variants (#204).