### PR TITLE
Include padding before first exon in track scale

### DIFF
--- a/packages/utilities/src/coordinates/index.js
+++ b/packages/utilities/src/coordinates/index.js
@@ -40,7 +40,7 @@ export const calculateRegionDistances = regions =>
     if (i === 0) {
       return {
         ...region,
-        previousRegionDistance: 0,
+        previousRegionDistance: Infinity,
       }
     }
     return {
@@ -63,12 +63,7 @@ export const addPadding = R.curry((padding, regions) => {
       start: region.stop + 1,
       stop: region.stop + padding,
     }
-    if (i === 0) {
-      return [
-        region,
-        endPad,
-      ]
-    }
+
     // check if total padding greater than distance between exons
     if (region.previousRegionDistance < padding * 2) {
       return [


### PR DESCRIPTION
Currently, a padding of 75 base pairs is added before and after each exon in the tracks' axis, except for before the first exon. However, the query still fetches variants located in those 75 base pairs before the first region. Thus, when those variants are displayed in the tracks, they are all compressed into the same pixel at the start of the first exon.

This change adds the 75 base pair padding before the first exon.

Before
<img width="1486" alt="before" src="https://user-images.githubusercontent.com/1156625/46643495-60643b00-cb4a-11e8-8386-2475eac24527.png">

After
<img width="1479" alt="after" src="https://user-images.githubusercontent.com/1156625/46643499-63f7c200-cb4a-11e8-9a11-44575e6f28b5.png">

Resolves #160