### PR TITLE
Consistent layout for gene and region pages

### DIFF
--- a/packages/region-viewer/src/RegionViewer.js
+++ b/packages/region-viewer/src/RegionViewer.js
@@ -14,6 +14,7 @@ const RegionViewerWrapper = styled.div`
   flex-direction: column;
   width: ${props => props.width}px;
   margin: 0 auto 10px;
+  font-size: 12px;
 `
 
 const exonColor = '#212121'

--- a/packages/ui/src/Page.js
+++ b/packages/ui/src/Page.js
@@ -66,3 +66,16 @@ export const SectionHeading = styled.h2`
   margin: 0 0 0.5em;
   font-size: 18px;
 `
+
+export const TrackPage = Page.extend`
+  max-width: none;
+`
+
+// Margins have to be kept in sync with region viewer width, which is currently based on screen size
+export const TrackPageSection = styled.section`
+  margin: 0 160px 1em 100px;
+
+  @media (max-width: 900px) {
+    margin: 0 15px 1em;
+  }
+`

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -72,7 +72,7 @@ export {
   InfoModal
 } from './modal/InfoModal'
 
-export { Page, PageHeading, SectionHeading } from './Page'
+export { Page, PageHeading, SectionHeading, TrackPage, TrackPageSection } from './Page'
 
 export { SegmentedControl } from './SegmentedControl'
 

--- a/projects/gnomad/src/GenePage/RegionViewer.js
+++ b/projects/gnomad/src/GenePage/RegionViewer.js
@@ -9,7 +9,7 @@ import { TranscriptTrackConnected } from '@broad/track-transcript'
 import CoverageTrack from '@broad/track-coverage'
 import RegionalConstraintTrack from '@broad/track-regional-constraint'
 import { VariantAlleleFrequencyTrack } from '@broad/track-variant'
-import { screenSize, SectionTitle } from '@broad/ui'
+import { screenSize } from '@broad/ui'
 
 import {
   currentTranscript,
@@ -62,12 +62,6 @@ export const getCoverageConfig = (
   }
 }
 
-const RegionViewerWrapper = styled.div`
-  margin-left: 10px;
-  width: 100%;
-`
-
-
 const TranscriptLink = styled(({ isCanonical, isSelected, ...rest }) => <Link {...rest} />)`
   background-color: ${({ isSelected }) => isSelected ? 'rgba(10, 121, 191, 0.1)' : 'none'};
   border-bottom: ${({ isSelected, isCanonical }) => {
@@ -94,8 +88,9 @@ const GeneViewer = ({
   regionalConstraint,
   screenSize,
 }) => {
+  // Margins have to be kept in sync with styles in ui/Page.js
   const smallScreen = screenSize.width < 900
-  const regionViewerWidth = smallScreen ? screenSize.width - 150 : screenSize.width - 330
+  const regionViewerWidth = smallScreen ? screenSize.width - 130 : screenSize.width - 290
 
   const geneJS = gene.toJS()
   const currentTranscriptId = currentTranscript || gene.get('canonical_transcript')
@@ -118,13 +113,6 @@ const GeneViewer = ({
     genome_coverage
   )
 
-  const RegionViewerSectionTitle = SectionTitle.extend`
-    margin-left: 80px;
-    @media (max-width: 900px) {
-      margin-left: 0;
-    }
-  `
-
   const datasetTranslations = {
     gnomadExomeVariants: 'gnomAD exomes',
     gnomadGenomeVariants: 'gnomAD genomes',
@@ -133,52 +121,49 @@ const GeneViewer = ({
   }
 
   return (
-    <RegionViewerWrapper>
-      {/* <RegionViewerSectionTitle>Positional data</RegionViewerSectionTitle> */}
-      <RegionViewer
-        width={regionViewerWidth}
-        padding={exonPadding}
-        regions={canonicalExons}
-        regionAttributes={attributeConfig}
-      >
-        <CoverageTrack
-          title={'Coverage'}
-          height={200}
-          dataConfig={coverageConfig}
-          yTickNumber={11}
-          yMax={110}
-          totalBp={totalBasePairs}
-        />
-        <TranscriptTrackConnected
-          height={12}
-          renderTranscriptId={(transcriptId, { isCanonical, isSelected }) => (
-            <TranscriptLink
-              to={`/gene/${gene.get('gene_name')}/transcript/${transcriptId}`}
-              isCanonical={isCanonical}
-              isSelected={isSelected}
-            >
-              {transcriptId}
-            </TranscriptLink>
-          )}
-          showRightPanel={!smallScreen}
-        />
+    <RegionViewer
+      width={regionViewerWidth}
+      padding={exonPadding}
+      regions={canonicalExons}
+      regionAttributes={attributeConfig}
+    >
+      <CoverageTrack
+        title={'Coverage'}
+        height={200}
+        dataConfig={coverageConfig}
+        yTickNumber={11}
+        yMax={110}
+        totalBp={totalBasePairs}
+      />
+      <TranscriptTrackConnected
+        height={12}
+        renderTranscriptId={(transcriptId, { isCanonical, isSelected }) => (
+          <TranscriptLink
+            to={`/gene/${gene.get('gene_name')}/transcript/${transcriptId}`}
+            isCanonical={isCanonical}
+            isSelected={isSelected}
+          >
+            {transcriptId}
+          </TranscriptLink>
+        )}
+        showRightPanel={!smallScreen}
+      />
 
-        <ClinVarTrack variants={gene.get('clinvar_variants').toJS()} />
+      <ClinVarTrack variants={gene.get('clinvar_variants').toJS()} />
 
-        {regionalConstraint.length > 0 && selectedVariantDataset === 'exacVariants' &&
-          <RegionalConstraintTrack
-            height={15}
-            regionalConstraintData={regionalConstraint}
-            strand={strand}
-          />}
+      {regionalConstraint.length > 0 && selectedVariantDataset === 'exacVariants' &&
+        <RegionalConstraintTrack
+          height={15}
+          regionalConstraintData={regionalConstraint}
+          strand={strand}
+        />}
 
-        <VariantAlleleFrequencyTrack
-          title={`${datasetTranslations[selectedVariantDataset]}\n(${allVariants.size})`}
-          variants={variantsReversed.toJS()}
-        />
-        <NavigatorTrackConnected title={'Viewing in table'} />
-      </RegionViewer>
-    </RegionViewerWrapper>
+      <VariantAlleleFrequencyTrack
+        title={`${datasetTranslations[selectedVariantDataset]}\n(${allVariants.size})`}
+        variants={variantsReversed.toJS()}
+      />
+      <NavigatorTrackConnected title={'Viewing in table'} />
+    </RegionViewer>
   )
 }
 

--- a/projects/gnomad/src/GenePage/index.js
+++ b/projects/gnomad/src/GenePage/index.js
@@ -7,7 +7,7 @@ import { QuestionMark } from '@broad/help'
 import { GenePageHoc } from '@broad/redux-genes'
 import { actions as variantActions } from '@broad/redux-variants'
 import { VariantTable } from '@broad/table'
-import { ClassicExacButton, GenePage, SectionHeading, TableSection } from '@broad/ui'
+import { ClassicExacButton, SectionHeading, TrackPage, TrackPageSection } from '@broad/ui'
 
 import GnomadPageHeading from '../GnomadPageHeading'
 import Settings from '../Settings'
@@ -32,18 +32,6 @@ const ExportVariantsButton = connect(
   })
 )(ClassicExacButton)
 
-/**
- * FIXME
- * This section previously had a 97% width left aligned div nested in a 90% width centered div.
- * This imitates the same layout with fewer elements. The horizontal alignment of various sections
- * needs to be made consistent.
- */
-const GeneInfoSection = styled.div`
-  width: 87%;
-  padding-right: 3%;
-  margin-bottom: 10px;
-`
-
 const GeneFullName = styled.span`
   font-size: 22px;
   font-weight: 400;
@@ -64,8 +52,8 @@ const GenePageConnected = ({ gene }) => {
   console.log(gene)
   const { gene_name: geneSymbol, full_gene_name: fullGeneName } = gene
   return (
-    <GenePage>
-      <GeneInfoSection>
+    <TrackPage>
+      <TrackPageSection>
         <GnomadPageHeading>
           {geneSymbol} <GeneFullName>{fullGeneName}</GeneFullName>
         </GnomadPageHeading>
@@ -78,16 +66,16 @@ const GenePageConnected = ({ gene }) => {
             <ConstraintTableOrPlaceholder />
           </div>
         </GeneInfoColumnWrapper>
-      </GeneInfoSection>
+      </TrackPageSection>
       <GeneViewer />
-      <TableSection>
+      <TrackPageSection>
         <Settings />
         <VariantTable tableConfig={tableConfig} />
         <BottomButtonSection>
           <ExportVariantsButton>Export variants</ExportVariantsButton>
         </BottomButtonSection>
-      </TableSection>
-    </GenePage>
+      </TrackPageSection>
+    </TrackPage>
   )
 }
 

--- a/projects/gnomad/src/RegionPage/RegionViewer.js
+++ b/projects/gnomad/src/RegionPage/RegionViewer.js
@@ -61,8 +61,9 @@ const RegionViewerConnected = ({
 
   const totalBp = stop - start
 
+  // Margins have to be kept in sync with styles in ui/Page.js
   const smallScreen = screenSize.width < 900
-  const regionViewerWidth = smallScreen ? screenSize.width - 150 : screenSize.width - 300
+  const regionViewerWidth = smallScreen ? screenSize.width - 130 : screenSize.width - 290
 
   const datasetTranslations = {
     gnomadExomeVariants: 'gnomAD exomes',
@@ -72,39 +73,37 @@ const RegionViewerConnected = ({
   }
 
   return (
-    <div>
-      <RegionViewer
-        width={regionViewerWidth}
-        padding={0}
-        regions={regions}
-        regionAttributes={attributeConfig}
-        featuresToDisplay={featuresToDisplay}
-        leftPanelWidth={100}
-      >
-        <CoverageTrack
-          title={'Coverage'}
-          height={200}
-          dataConfig={coverageConfig}
-          yTickNumber={11}
-          yMax={110}
-          totalBp={totalBp}
+    <RegionViewer
+      width={regionViewerWidth}
+      padding={0}
+      regions={regions}
+      regionAttributes={attributeConfig}
+      featuresToDisplay={featuresToDisplay}
+      leftPanelWidth={100}
+    >
+      <CoverageTrack
+        title={'Coverage'}
+        height={200}
+        dataConfig={coverageConfig}
+        yTickNumber={11}
+        yMax={110}
+        totalBp={totalBp}
+      />
+
+      <GenesTrack
+        genes={genes}
+        onGeneClick={geneName => history.push(`/gene/${geneName}`)}
+      />
+
+      {showVariants && (
+        <VariantAlleleFrequencyTrack
+          title={`${datasetTranslations[selectedVariantDataset]}\n(${allVariants.size})`}
+          variants={variantsReversed.toJS()}
         />
+      )}
 
-        <GenesTrack
-          genes={genes}
-          onGeneClick={geneName => history.push(`/gene/${geneName}`)}
-        />
-
-        {showVariants && (
-          <VariantAlleleFrequencyTrack
-            title={`${datasetTranslations[selectedVariantDataset]}\n(${allVariants.size})`}
-            variants={variantsReversed.toJS()}
-          />
-        )}
-
-        {showVariants && <NavigatorTrackConnected title="Viewing in table" />}
-      </RegionViewer>
-    </div>
+      {showVariants && <NavigatorTrackConnected title="Viewing in table" />}
+    </RegionViewer>
   )
 }
 RegionViewerConnected.propTypes = {

--- a/projects/gnomad/src/RegionPage/index.js
+++ b/projects/gnomad/src/RegionPage/index.js
@@ -1,10 +1,9 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
 
 import { RegionHoc } from '@broad/region'
 import { VariantTable } from '@broad/table'
-import { GenePage, TableSection } from '@broad/ui'
+import { TrackPage, TrackPageSection } from '@broad/ui'
 
 import GnomadPageHeading from '../GnomadPageHeading'
 import Settings from '../Settings'
@@ -13,43 +12,31 @@ import { fetchRegion } from './fetch'
 import RegionInfo from './RegionInfo'
 import RegionViewer from './RegionViewer'
 
-/**
- * FIXME
- * This section previously had a 97% width left aligned div nested in a 90% width centered div.
- * This imitates the same layout with fewer elements. The horizontal alignment of various sections
- * needs to be made consistent.
- */
-const RegionInfoSection = styled.div`
-  width: 87%;
-  padding-right: 3%;
-  margin-bottom: 10px;
-`
-
 const tooManyVariantsError = /Individual variants can only be returned for regions with fewer than \d+ variants/
 
 const RegionPage = ({ errors, region }) => {
   const showVariants = !(errors && errors.some(err => tooManyVariantsError.test(err.message)))
   return (
-    <GenePage>
-      <RegionInfoSection>
+    <TrackPage>
+      <TrackPageSection>
         <GnomadPageHeading>{`${region.chrom}-${region.start}-${region.stop}`}</GnomadPageHeading>
         <div>
           <RegionInfo showVariants={showVariants} />
         </div>
-      </RegionInfoSection>
+      </TrackPageSection>
       <RegionViewer coverageStyle={'new'} showVariants={showVariants} />
       {showVariants ? (
-        <TableSection>
+        <TrackPageSection>
           <Settings />
           <VariantTable tableConfig={tableConfig} />
-        </TableSection>
+        </TrackPageSection>
       ) : (
         <p>
           This region has too many variants to display. To view individual variants, select a
           smaller region.
         </p>
       )}
-    </GenePage>
+    </TrackPage>
   )
 }
 


### PR DESCRIPTION
Add components for pages with tracks and use them in gnomAD to ensure that the page layout is consistent between the gene and region pages.

This also aligns all the page content with the track graphs.

Before
<img width="1016" alt="screen shot 2018-10-09 at 10 10 23 am" src="https://user-images.githubusercontent.com/1156625/46675882-6b9c8280-cbad-11e8-81a8-11735e6ac17a.png">

After
<img width="1016" alt="screen shot 2018-10-09 at 10 10 21 am" src="https://user-images.githubusercontent.com/1156625/46675884-6b9c8280-cbad-11e8-94db-d5de87a1b712.png">



Resolves #164