### PR TITLE
Fix text of link to UCSC browser

### DIFF
--- a/projects/gnomad/src/GenePage/GeneInfo.js
+++ b/projects/gnomad/src/GenePage/GeneInfo.js
@@ -58,7 +58,7 @@ const GeneInfo = ({ currentTranscript, gene, variantCount }) => {
         <GeneAttributeValue>{variantCount}</GeneAttributeValue>
         <GeneAttributeValue>
           <a target="_blank" href={ucscUrl}>
-            {`${chrom}:${start}:${stop}`}
+            {`${chrom}:${start}-${stop}`}
           </a>
         </GeneAttributeValue>
         <GeneAttributeValue>


### PR DESCRIPTION
@konradjk pointed out there should be a "-" instead of a ":" between the start and stop position.