### PR TITLE
Prevent consequence filter control from wrapping at any window width

### DIFF
--- a/packages/ui/src/ConsequenceCategoriesControl.js
+++ b/packages/ui/src/ConsequenceCategoriesControl.js
@@ -20,6 +20,17 @@ const categoryLabels = {
   other: 'Other',
 }
 
+// The max-width styles here are based on the filter settings
+// layout in the gnomAD browser.
+
+const ConsequenceCategoriesControlWrapper = styled.div`
+  @media (max-width: 700px) {
+    display: flex;
+    flex-direction: column;
+    width: fit-content;
+  }
+`
+
 const Button = styled.button`
   box-sizing: border-box;
   width: 35px;
@@ -73,6 +84,7 @@ const Checkbox = styled.input.attrs({ type: 'checkbox' })`
 
 const CategoryWrapper = styled.span`
   display: inline-flex;
+  flex-shrink: 0;
   align-items: center;
   overflow: hidden;
   border-color: ${props => props.borderColor};
@@ -88,16 +100,23 @@ const CategoryWrapper = styled.span`
     border-top-right-radius: 0.5em;
     border-bottom-right-radius: 0.5em;
   }
+
+  @media (max-width: 700px) {
+    margin-bottom: 0.25em;
+    border-radius: 0.5em;
+  }
 `
 
 const Label = styled.label`
   display: inline-flex;
+  flex-grow: 1;
   align-items: center;
   margin: 0; /* Override Bootstrap in gnomad_browser */
   background: ${props =>
     `linear-gradient(to right, ${props.backgroundColor}, ${
       props.backgroundColor
     } 2em, rgba(0, 0, 0, 0) 2em, rgba(0, 0, 0, 0))`};
+  background-repeat: no-repeat;
   font-size: 14px;
   font-weight: normal; /* Override Bootstrap in gnomad_browser */
   user-select: none;
@@ -147,7 +166,7 @@ export class ConsequenceCategoriesControl extends Component {
     const { categorySelections, id, onChange } = this.props
 
     return (
-      <div>
+      <ConsequenceCategoriesControlWrapper>
         {categories.map(category => (
           <CategoryWrapper key={category} borderColor={categoryColors[category]}>
             <Label
@@ -183,7 +202,7 @@ export class ConsequenceCategoriesControl extends Component {
             </Button>
           </CategoryWrapper>
         ))}
-      </div>
+      </ConsequenceCategoriesControlWrapper>
     )
   }
 }

--- a/projects/gnomad/src/Settings.js
+++ b/projects/gnomad/src/Settings.js
@@ -9,11 +9,22 @@ import { Checkbox, ConsequenceCategoriesControl, Search } from '@broad/ui'
 
 const SettingsWrapper = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-flow: row wrap;
   justify-content: space-between;
+  align-items: center;
   width: 100%;
 
-  @media (max-width: 1300px) {
+  @media (max-width: 1300px) and (min-width: 1101px) {
+    > div {
+      &:nth-child(2) {
+        order: 3;
+        width: 50%;
+        margin-top: 1em;
+      }
+    }
+  }
+
+  @media (max-width: 1100px) {
     flex-direction: column;
     align-items: center;
 

--- a/projects/gnomad/src/Settings.js
+++ b/projects/gnomad/src/Settings.js
@@ -13,7 +13,7 @@ const SettingsWrapper = styled.div`
   justify-content: space-between;
   width: 100%;
 
-  @media (max-width: 900px) {
+  @media (max-width: 1300px) {
     flex-direction: column;
     align-items: center;
 


### PR DESCRIPTION
Currently, certain window widths cause the consequence filter control to wrap to multiple lines.

![46690264-d65eb580-cbcf-11e8-84ad-6d84f3d49a62](https://user-images.githubusercontent.com/1156625/46693659-7587ab00-cbd8-11e8-97d9-9f5083d591d1.png)

This change has the settings section switch from row to column layout at 1300px instead of 900px and adds a more phone-friendly layout for the consequence filter control for windows less than 700px wide.

<img width="545" alt="screen shot 2018-10-09 at 3 29 55 pm" src="https://user-images.githubusercontent.com/1156625/46693665-791b3200-cbd8-11e8-9766-db69a8fd4f8a.png">

Resolves #282