### PR TITLE
Prevent horizontal scroll on narrow screens

### DIFF
--- a/projects/gnomad/src/GenePage/RegionViewer.js
+++ b/projects/gnomad/src/GenePage/RegionViewer.js
@@ -126,6 +126,7 @@ const GeneViewer = ({
       padding={exonPadding}
       regions={canonicalExons}
       regionAttributes={attributeConfig}
+      rightPanelWidth={smallScreen ? 0 : 160}
     >
       <CoverageTrack
         title={'Coverage'}

--- a/projects/gnomad/src/RegionPage/RegionViewer.js
+++ b/projects/gnomad/src/RegionPage/RegionViewer.js
@@ -79,7 +79,7 @@ const RegionViewerConnected = ({
       regions={regions}
       regionAttributes={attributeConfig}
       featuresToDisplay={featuresToDisplay}
-      leftPanelWidth={100}
+      rightPanelWidth={smallScreen ? 0 : 160}
     >
       <CoverageTrack
         title={'Coverage'}


### PR DESCRIPTION
On narrow screens, the entire browser can be horizontally scrolled and there is 160px of blank space to the right of the content.

<img width="545" alt="screen shot 2018-10-09 at 3 35 44 pm" src="https://user-images.githubusercontent.com/1156625/46694027-93a1db00-cbd9-11e8-95d4-827f802b20b4.png">

On narrow screens (< 900px wide), the tissue expression section is not shown. The region viewer width is calculated based on the tissue expression section not being present. However, the region viewer still reserves 160px for the section.

This change tells the region viewer component not to reserve space for the section which is not displayed.
