### PR TITLE
Fetch variants separately from gene/region data

### DIFF
--- a/packages/redux-variants/index.js
+++ b/packages/redux-variants/index.js
@@ -12,6 +12,7 @@ export {
   variantQcFilter,
   variantDeNovoFilter,
   variantSearchQuery,
+  isLoadingVariants,
   finalFilteredVariants,
   focusedVariant,
 } from './variants'

--- a/projects/gnomad/package.json
+++ b/projects/gnomad/package.json
@@ -36,6 +36,7 @@
     "igv": "^2.0.0-rc2",
     "isomorphic-fetch": "^2.2.1",
     "prop-types": "^15.5.10",
+    "query-string": "5",
     "ramda": "^0.24.1",
     "react-redux": "^5.0.4",
     "react-router-dom": "^4.1.1",

--- a/projects/gnomad/src/GenePage/Constraint.js
+++ b/projects/gnomad/src/GenePage/Constraint.js
@@ -90,7 +90,7 @@ export const ConstraintTableOrPlaceholder = connect(state => ({
   geneData: geneData(state).toJS(),
   selectedVariantDataset: selectedVariantDataset(state),
 }))(({ geneData, selectedVariantDataset }) => {
-  if (selectedVariantDataset === 'exacVariants') {
+  if (selectedVariantDataset === 'exac') {
     const exacConstraint = geneData.exacv1_constraint
     if (!exacConstraint) {
       return <ConstraintTablePlaceholder message="ExAC constraint not available for this gene" />
@@ -98,9 +98,5 @@ export const ConstraintTableOrPlaceholder = connect(state => ({
     return <ConstraintTable constraintData={exacConstraint} />
   }
 
-  if (selectedVariantDataset === 'gnomadCombinedVariants') {
-    return <ConstraintTablePlaceholder message="gnomAD constraint coming soon!" />
-  }
-
-  return null
+  return <ConstraintTablePlaceholder message="gnomAD constraint coming soon!" />
 })

--- a/projects/gnomad/src/GenePage/GeneDataContainer.js
+++ b/projects/gnomad/src/GenePage/GeneDataContainer.js
@@ -1,0 +1,189 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
+import { actions as geneActions } from '@broad/redux-genes'
+import { actions as variantActions } from '@broad/redux-variants'
+
+import StatusMessage from '../StatusMessage'
+
+const GeneDataContainer = connect(
+  null,
+  (dispatch, ownProps) => ({
+    loadGene() {
+      return dispatch(thunkDispatch => {
+        thunkDispatch(geneActions.setCurrentGene(ownProps.geneIdOrName))
+        thunkDispatch(geneActions.setCurrentTranscript(ownProps.transcriptId))
+        thunkDispatch(geneActions.requestGeneData(ownProps.geneIdOrName))
+        return ownProps.fetchGene(ownProps.geneIdOrName, ownProps.transcriptId).then(response => {
+          const geneData = response.data.gene
+          thunkDispatch(geneActions.receiveGeneData(ownProps.geneIdOrName, geneData))
+          return response
+        })
+      })
+    },
+    loadVariants() {
+      return dispatch(thunkDispatch => {
+        thunkDispatch(variantActions.setSelectedVariantDataset(ownProps.datasetId))
+        thunkDispatch(variantActions.requestVariants())
+        return ownProps
+          .fetchVariants(ownProps.geneIdOrName, ownProps.transcriptId, ownProps.datasetId)
+          .then(response => {
+            const variantData = response.data.gene
+            thunkDispatch(variantActions.receiveVariants(variantData))
+
+            // Reset variant filters when loading a new gene
+            thunkDispatch(variantActions.searchVariants(''))
+            thunkDispatch(
+              variantActions.setVariantFilter({
+                lof: true,
+                missense: true,
+                synonymous: true,
+                other: true,
+              })
+            )
+
+            return response
+          })
+      })
+    },
+  })
+)(
+  class GeneData extends Component {
+    static propTypes = {
+      children: PropTypes.func.isRequired,
+      datasetId: PropTypes.string.isRequired,
+      geneIdOrName: PropTypes.string.isRequired,
+      loadGene: PropTypes.func.isRequired,
+      loadVariants: PropTypes.func.isRequired,
+      transcriptId: PropTypes.string,
+    }
+
+    static defaultProps = {
+      transcriptId: undefined,
+    }
+
+    state = {
+      geneData: null,
+      isLoadingGene: false,
+      isLoadingVariants: false,
+      loadError: null,
+    }
+
+    componentDidMount() {
+      this.mounted = true
+      this.loadGene()
+      this.loadVariants()
+    }
+
+    componentDidUpdate(prevProps) {
+      if (
+        this.props.geneIdOrName !== prevProps.geneIdOrName ||
+        this.props.transcriptId !== prevProps.transcriptId
+      ) {
+        this.loadGene()
+        this.loadVariants()
+      } else if (this.props.datasetId !== prevProps.datasetId) {
+        this.loadVariants()
+      }
+    }
+
+    componentWillUnmount() {
+      this.mounted = false
+    }
+
+    loadGene() {
+      this.setState({
+        isLoadingGene: true,
+        loadError: null,
+      })
+
+      this.props
+        .loadGene()
+        .then(response => {
+          const geneData = response.data.gene
+          let loadError = null
+          if (!geneData) {
+            loadError = 'Gene not found'
+          }
+          if (
+            this.props.transcriptId &&
+            !geneData.transcripts.map(t => t.transcript_id).includes(this.props.transcriptId)
+          ) {
+            loadError = 'Transcript not found'
+          }
+          if (!this.mounted) {
+            return
+          }
+          this.setState({
+            geneData,
+            isLoadingGene: false,
+            loadError,
+          })
+        })
+        .catch(() => {
+          if (!this.mounted) {
+            return
+          }
+          this.setState({
+            geneData: null,
+            isLoadingGene: false,
+            loadError: 'Unable to load gene',
+          })
+        })
+    }
+
+    loadVariants() {
+      this.setState({ isLoadingVariants: true })
+
+      this.props
+        .loadVariants()
+        .then(() => {
+          if (!this.mounted) {
+            return
+          }
+          this.setState({ isLoadingVariants: false })
+        })
+        .catch(() => {
+          if (!this.mounted) {
+            return
+          }
+          this.setState({ isLoadingVariants: false })
+        })
+    }
+
+    render() {
+      if (this.state.isLoadingGene) {
+        return <StatusMessage>Loading gene...</StatusMessage>
+      }
+
+      if (this.state.loadError) {
+        return <StatusMessage>{this.state.loadError}</StatusMessage>
+      }
+
+      if (this.state.geneData) {
+        return this.props.children({
+          gene: this.state.geneData,
+          isLoadingVariants: this.state.isLoadingVariants,
+        })
+      }
+
+      return null
+    }
+  }
+)
+
+GeneDataContainer.propTypes = {
+  children: PropTypes.func.isRequired,
+  datasetId: PropTypes.string.isRequired,
+  fetchGene: PropTypes.func.isRequired,
+  fetchVariants: PropTypes.func.isRequired,
+  geneIdOrName: PropTypes.string.isRequired,
+  transcriptId: PropTypes.string,
+}
+
+GeneDataContainer.defaultProps = {
+  transcriptId: undefined,
+}
+
+export default GeneDataContainer

--- a/projects/gnomad/src/GenePage/fetch.js
+++ b/projects/gnomad/src/GenePage/fetch.js
@@ -40,42 +40,6 @@ export const fetchGnomadGenePage = (geneName, transcriptId) => {
         pos
         variantId
       }
-      gnomadCombinedVariants: variants(dataset: gnomad_r2_0_2${
-        transcriptId ? `, transcriptId: "${transcriptId}"` : ''
-      }) {
-        allele_count: ac
-        hemi_count: ac_hemi
-        hom_count: ac_hom
-        allele_num: an
-        allele_freq: af
-        consequence
-        datasets
-        filters
-        flags
-        hgvsc
-        hgvsp
-        pos
-        rsid
-        variant_id: variantId
-        xpos
-      }
-      exacVariants: variants(dataset:exac) {
-        allele_count: ac
-        hemi_count: ac_hemi
-        hom_count: ac_hom
-        allele_num: an
-        allele_freq: af
-        consequence
-        datasets
-        filters
-        flags
-        hgvsc
-        hgvsp
-        pos
-        rsid
-        variant_id: variantId
-        xpos
-      }
       exacv1_constraint {
         mu_syn
         exp_syn
@@ -209,11 +173,5 @@ export const fetchGnomadGenePage = (geneName, transcriptId) => {
     }
 }
 `
-  return new Promise((resolve, reject) => {
-    fetch(API_URL)(query)
-      .then(data => resolve(data.data.gene))
-      .catch((error) => {
-        reject(error)
-      })
-  })
+  return fetch(API_URL)(query)
 }

--- a/projects/gnomad/src/GenePage/fetchVariantsByGene.js
+++ b/projects/gnomad/src/GenePage/fetchVariantsByGene.js
@@ -1,0 +1,39 @@
+import fetch from 'graphql-fetch'
+
+const fetchVariantsByGene = (geneIdOrName, transcriptId, datasetId) => {
+  const geneArg = geneIdOrName.startsWith('ENSG')
+    ? `gene_id: "${geneIdOrName}"`
+    : `gene_name: "${geneIdOrName}"`
+
+  let variantsArgs = `dataset: ${datasetId}`
+  if (transcriptId) {
+    variantsArgs += `, transcriptId: "${transcriptId}"`
+  }
+
+  const query = `{
+    gene(${geneArg}) {
+      ${datasetId}: variants(${variantsArgs}) {
+        allele_count: ac
+        hemi_count: ac_hemi
+        hom_count: ac_hom
+        allele_num: an
+        allele_freq: af
+        consequence
+        datasets
+        filters
+        flags
+        hgvsc
+        hgvsp
+        pos
+        rsid
+        variant_id: variantId
+        xpos
+      }
+    }
+  }
+  `
+
+  return fetch(process.env.GNOMAD_API_URL)(query)
+}
+
+export default fetchVariantsByGene

--- a/projects/gnomad/src/GnomadPageHeading.js
+++ b/projects/gnomad/src/GnomadPageHeading.js
@@ -1,46 +1,54 @@
 import PropTypes from 'prop-types'
+import queryString from 'query-string'
 import React from 'react'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
 
 import { QuestionMark } from '@broad/help'
-import { actions as variantActions, selectedVariantDataset } from '@broad/redux-variants'
+import { selectedVariantDataset } from '@broad/redux-variants'
 import { Combobox, PageHeading } from '@broad/ui'
 
-const datasetLabels = {
-  exacVariants: 'ExAC',
-  gnomadCombinedVariants: 'gnomAD',
-}
+import datasetLabels from './datasetLabels'
 
-const GnomadPageHeading = connect(
-  state => ({ selectedVariantDataset: selectedVariantDataset(state) }),
-  dispatch => ({
-    setSelectedVariantDataset: dataset =>
-      dispatch(variantActions.setSelectedVariantDataset(dataset)),
-  })
-)(({ children, selectedVariantDataset, setSelectedVariantDataset }) => (
-  <PageHeading
-    renderPageControls={() => (
-      <div>
-        {/* eslint-disable jsx-a11y/label-has-for */}
-        <label htmlFor="dataset-selector">Current Dataset </label>
-        <Combobox
-          id="dataset-selector"
-          options={['gnomadCombinedVariants', 'exacVariants'].map(datasetId => ({
-            label: datasetLabels[datasetId],
-            value: datasetId,
-          }))}
-          value={datasetLabels[selectedVariantDataset]}
-          width="100px"
-          onChange={setSelectedVariantDataset}
-        />
+const GnomadPageHeading = withRouter(
+  connect(state => ({ selectedVariantDataset: selectedVariantDataset(state) }))(
+    ({ children, history, selectedVariantDataset }) => (
+      <PageHeading
+        renderPageControls={() => (
+          <div>
+            {/* eslint-disable jsx-a11y/label-has-for */}
+            <label htmlFor="dataset-selector">Current Dataset </label>
+            <Combobox
+              id="dataset-selector"
+              // FIXME
+              // Using key forces a re-render when dataset changes
+              // Otherwise, the menu doesn't update when the dataset is changed with
+              // the browser's forward/back buttons.
+              // This is likely a bug in Combobox.
+              key={selectedVariantDataset}
+              options={['gnomad_r2_0_2', 'exac'].map(datasetId => ({
+                label: datasetLabels[datasetId],
+                value: datasetId,
+              }))}
+              value={datasetLabels[selectedVariantDataset]}
+              width="150px"
+              onChange={datasetId => {
+                const nextLocation = Object.assign(history.location, {
+                  search: queryString.stringify({ dataset: datasetId }),
+                })
+                history.push(nextLocation)
+              }}
+            />
 
-        <QuestionMark topic={'dataset-selection'} display={'inline'} />
-      </div>
-    )}
-  >
-    {children}
-  </PageHeading>
-))
+            <QuestionMark topic={'dataset-selection'} display={'inline'} />
+          </div>
+        )}
+      >
+        {children}
+      </PageHeading>
+    )
+  )
+)
 
 GnomadPageHeading.propTypes = {
   children: PropTypes.node.isRequired,

--- a/projects/gnomad/src/Main.js
+++ b/projects/gnomad/src/Main.js
@@ -35,48 +35,32 @@ const appSettings = {
     startingVariant: '13-32900634-AG-A',
     startingRegion: '1-55530000-55540000',
     startingPadding: 75,
-    startingVariantDataset: 'gnomadCombinedVariants',
     startingQcFilter: true,
   },
-  variantDatasets: {
-    gnomadCombinedVariants: {
-      id: null,
-      variant_id: null,
-      rsid: null,
-      pos: null,
-      xpos: null,
-      hgvsc: null,
-      hgvsp: null,
-      allele_count: null,
-      allele_freq: null,
-      allele_num: null,
-      filters: null,
-      hom_count: null,
-      hemi_count: null,
-      consequence: null,
-      flags: [],
-      datasets: [],
-    },
-    exacVariants: {
-      id: null,
-      variant_id: null,
-      rsid: null,
-      pos: null,
-      xpos: null,
-      hgvsc: null,
-      hgvsp: null,
-      allele_count: null,
-      allele_freq: null,
-      allele_num: null,
-      filters: null,
-      flags: [],
-      hom_count: null,
-      hemi_count: null,
-      consequence: null,
-      datasets: [],
-    },
-  },
+  variantDatasets: {},
 }
+
+const variantDatasets = ['exac', 'gnomad_r2_0_2']
+variantDatasets.forEach(datasetId => {
+  appSettings.variantDatasets[datasetId] = {
+    allele_count: null,
+    allele_freq: null,
+    allele_num: null,
+    consequence: null,
+    datasets: [],
+    filters: [],
+    flags: [],
+    hemi_count: null,
+    hgvsc: null,
+    hgvsp: null,
+    hom_count: null,
+    id: null,
+    variant_id: null,
+    rsid: null,
+    pos: null,
+    xpos: null,
+  }
+})
 
 const store = createGenePageStore(appSettings)
 

--- a/projects/gnomad/src/RegionPage/RegionDataContainer.js
+++ b/projects/gnomad/src/RegionPage/RegionDataContainer.js
@@ -1,0 +1,168 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
+import { actions as variantActions } from '@broad/redux-variants'
+import { actions as regionActions } from '@broad/region'
+
+import StatusMessage from '../StatusMessage'
+
+const RegionDataContainer = connect(
+  null,
+  (dispatch, ownProps) => ({
+    loadRegion() {
+      return dispatch(thunkDispatch => {
+        thunkDispatch(regionActions.setCurrentRegion(ownProps.regionId))
+        thunkDispatch(regionActions.requestRegionData(ownProps.regionId))
+        return ownProps.fetchRegion(ownProps.regionId).then(response => {
+          const regionData = response.data.region
+          thunkDispatch(regionActions.receiveRegionData(ownProps.regionId, regionData))
+          return response
+        })
+      })
+    },
+    loadVariants() {
+      return dispatch(thunkDispatch => {
+        thunkDispatch(variantActions.setSelectedVariantDataset(ownProps.datasetId))
+        thunkDispatch(variantActions.requestVariants())
+        return ownProps.fetchVariants(ownProps.regionId, ownProps.datasetId).then(response => {
+          const variantData = response.data.region
+          thunkDispatch(variantActions.receiveVariants(variantData))
+
+          // Reset variant filters when loading a new gene
+          thunkDispatch(variantActions.searchVariants(''))
+          thunkDispatch(
+            variantActions.setVariantFilter({
+              lof: true,
+              missense: true,
+              synonymous: true,
+              other: true,
+            })
+          )
+
+          return response
+        })
+      })
+    },
+  })
+)(
+  class RegionData extends Component {
+    static propTypes = {
+      children: PropTypes.func.isRequired,
+      datasetId: PropTypes.string.isRequired,
+      loadRegion: PropTypes.func.isRequired,
+      loadVariants: PropTypes.func.isRequired,
+      regionId: PropTypes.string.isRequired,
+    }
+
+    state = {
+      isLoadingRegion: false,
+      isLoadingVariants: false,
+      loadError: null,
+      regionData: null,
+      variantErrors: null,
+    }
+
+    componentDidMount() {
+      this.mounted = true
+      this.loadRegion()
+      this.loadVariants()
+    }
+
+    componentDidUpdate(prevProps) {
+      if (this.props.regionId !== prevProps.regionId) {
+        this.loadRegion()
+        this.loadVariants()
+      } else if (this.props.datasetId !== prevProps.datasetId) {
+        this.loadVariants()
+      }
+    }
+
+    componentWillUnmount() {
+      this.mounted = false
+    }
+
+    loadRegion() {
+      this.setState({
+        isLoadingRegion: true,
+        loadError: null,
+      })
+
+      this.props.loadRegion().then(
+        response => {
+          const regionData = response.data.region
+          if (!this.mounted) {
+            return
+          }
+          this.setState({
+            isLoadingRegion: false,
+            regionData,
+          })
+        },
+        () => {
+          if (!this.mounted) {
+            return
+          }
+          this.setState({
+            isLoadingRegion: false,
+            loadError: 'Unable to load region',
+          })
+        }
+      )
+    }
+
+    loadVariants() {
+      this.setState({
+        isLoadingVariants: true,
+        variantErrors: null,
+      })
+
+      this.props
+        .loadVariants()
+        .then(response => {
+          if (!this.mounted) {
+            return
+          }
+          this.setState({
+            isLoadingVariants: false,
+            variantErrors: response.errors,
+          })
+        })
+        .catch(() => {
+          if (!this.mounted) {
+            return
+          }
+          this.setState({ isLoadingVariants: false })
+        })
+    }
+
+    render() {
+      if (this.state.isLoadingRegion) {
+        return <StatusMessage>Loading region...</StatusMessage>
+      }
+
+      if (this.state.loadError) {
+        return <StatusMessage>{this.state.loadError}</StatusMessage>
+      }
+
+      if (this.state.regionData) {
+        return this.props.children({
+          variantErrors: this.state.variantErrors,
+          isLoadingVariants: this.state.isLoadingVariants,
+          region: this.state.regionData,
+        })
+      }
+
+      return null
+    }
+  }
+)
+
+RegionDataContainer.propTypes = {
+  children: PropTypes.func.isRequired,
+  datasetId: PropTypes.string.isRequired,
+  fetchRegion: PropTypes.func.isRequired,
+  regionId: PropTypes.string.isRequired,
+}
+
+export default RegionDataContainer

--- a/projects/gnomad/src/RegionPage/RegionViewer.js
+++ b/projects/gnomad/src/RegionPage/RegionViewer.js
@@ -10,7 +10,12 @@ import { GenesTrack } from '@broad/track-genes'
 
 import { screenSize } from '@broad/ui'
 import { regionData } from '@broad/region'
-import { RegionViewer, attributeConfig } from '@broad/region-viewer'
+import {
+  RegionViewer,
+  attributeConfig,
+  coverageConfigClassic,
+  coverageConfigNew,
+} from '@broad/region-viewer'
 import { NavigatorTrackConnected } from '@broad/track-navigator'
 
 import {
@@ -18,7 +23,7 @@ import {
   selectedVariantDataset,
 } from '@broad/redux-variants'
 
-import { getCoverageConfig } from '../GenePage/RegionViewer'
+import datasetLabels from '../datasetLabels'
 
 const RegionViewerConnected = ({
   regionData,
@@ -40,12 +45,10 @@ const RegionViewerConnected = ({
 
   const variantsReversed = allVariants.reverse()
 
-  const coverageConfig = getCoverageConfig(
-    selectedVariantDataset,
-    exacv1_coverage,
-    exome_coverage,
-    genome_coverage
-  )
+  const coverageConfig =
+    selectedVariantDataset === 'exac'
+      ? coverageConfigClassic(exacv1_coverage)
+      : coverageConfigNew(exome_coverage, genome_coverage)
 
   const featuresToDisplay = ['default']
 
@@ -64,13 +67,6 @@ const RegionViewerConnected = ({
   // Margins have to be kept in sync with styles in ui/Page.js
   const smallScreen = screenSize.width < 900
   const regionViewerWidth = smallScreen ? screenSize.width - 130 : screenSize.width - 290
-
-  const datasetTranslations = {
-    gnomadExomeVariants: 'gnomAD exomes',
-    gnomadGenomeVariants: 'gnomAD genomes',
-    gnomadCombinedVariants: 'gnomAD',
-    exacVariants: 'ExAC',
-  }
 
   return (
     <RegionViewer
@@ -97,7 +93,7 @@ const RegionViewerConnected = ({
 
       {showVariants && (
         <VariantAlleleFrequencyTrack
-          title={`${datasetTranslations[selectedVariantDataset]}\n(${allVariants.size})`}
+          title={`${datasetLabels[selectedVariantDataset]}\n(${allVariants.size})`}
           variants={variantsReversed.toJS()}
         />
       )}

--- a/projects/gnomad/src/RegionPage/fetch.js
+++ b/projects/gnomad/src/RegionPage/fetch.js
@@ -48,40 +48,6 @@ export const fetchRegion = regionId => {
       pos
       mean
     }
-    gnomadCombinedVariants: variants(dataset: gnomad_r2_0_2) {
-      allele_count: ac
-      hemi_count: ac_hemi
-      hom_count: ac_hom
-      allele_num: an
-      allele_freq: af
-      consequence
-      datasets
-      filters
-      flags
-      hgvsc
-      hgvsp
-      pos
-      rsid
-      variant_id: variantId
-      xpos
-    }
-    exacVariants: variants(dataset:exac) {
-      allele_count: ac
-      hemi_count: ac_hemi
-      hom_count: ac_hom
-      allele_num: an
-      allele_freq: af
-      consequence
-      datasets
-      filters
-      flags
-      hgvsc
-      hgvsp
-      pos
-      rsid
-      variant_id: variantId
-      xpos
-    }
   }
 
 }

--- a/projects/gnomad/src/RegionPage/fetchVariantsByRegion.js
+++ b/projects/gnomad/src/RegionPage/fetchVariantsByRegion.js
@@ -1,0 +1,32 @@
+import fetch from 'graphql-fetch'
+
+const fetchVariantsByRegion = (regionId, datasetId) => {
+  const [chrom, start, stop] = regionId.split('-')
+
+  const query = `{
+    region(start: ${start}, stop: ${stop}, chrom: "${chrom}") {
+      ${datasetId}: variants(dataset: ${datasetId}) {
+        allele_count: ac
+        hemi_count: ac_hemi
+        hom_count: ac_hom
+        allele_num: an
+        allele_freq: af
+        consequence
+        datasets
+        filters
+        flags
+        hgvsc
+        hgvsp
+        pos
+        rsid
+        variant_id: variantId
+        xpos
+      }
+    }
+  }
+  `
+
+  return fetch(process.env.GNOMAD_API_URL)(query)
+}
+
+export default fetchVariantsByRegion

--- a/projects/gnomad/src/RegionPage/index.js
+++ b/projects/gnomad/src/RegionPage/index.js
@@ -1,60 +1,86 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { Component } from 'react'
 
-import { RegionHoc } from '@broad/region'
 import { VariantTable } from '@broad/table'
 import { TrackPage, TrackPageSection } from '@broad/ui'
 
 import GnomadPageHeading from '../GnomadPageHeading'
 import Settings from '../Settings'
+import StatusMessage from '../StatusMessage'
 import tableConfig from '../tableConfig'
 import { fetchRegion } from './fetch'
+import fetchVariantsByRegion from './fetchVariantsByRegion'
+import RegionDataContainer from './RegionDataContainer'
 import RegionInfo from './RegionInfo'
 import RegionViewer from './RegionViewer'
 
 const tooManyVariantsError = /Individual variants can only be returned for regions with fewer than \d+ variants/
 
-const RegionPage = ({ errors, region }) => {
-  const showVariants = !(errors && errors.some(err => tooManyVariantsError.test(err.message)))
-  return (
-    <TrackPage>
-      <TrackPageSection>
-        <GnomadPageHeading>{`${region.chrom}-${region.start}-${region.stop}`}</GnomadPageHeading>
-        <div>
-          <RegionInfo showVariants={showVariants} />
-        </div>
-      </TrackPageSection>
-      <RegionViewer coverageStyle={'new'} showVariants={showVariants} />
-      {showVariants ? (
+class RegionPage extends Component {
+  static propTypes = {
+    datasetId: PropTypes.string.isRequired,
+    regionId: PropTypes.string.isRequired,
+  }
+
+  renderRegion = ({ isLoadingVariants, variantErrors }) => {
+    const tooManyVariants =
+      variantErrors && variantErrors.some(err => tooManyVariantsError.test(err.message))
+    return (
+      <TrackPage>
         <TrackPageSection>
-          <Settings />
-          <VariantTable tableConfig={tableConfig} />
+          <GnomadPageHeading>{this.props.regionId}</GnomadPageHeading>
+          <div>
+            <RegionInfo showVariants={!tooManyVariants} />
+          </div>
         </TrackPageSection>
-      ) : (
-        <p>
-          This region has too many variants to display. To view individual variants, select a
-          smaller region.
-        </p>
-      )}
-    </TrackPage>
-  )
+        <RegionViewer coverageStyle={'new'} showVariants={!isLoadingVariants && !tooManyVariants} />
+        {this.renderVariants({ isLoadingVariants, tooManyVariants })}
+      </TrackPage>
+    )
+  }
+
+  /* eslint-disable class-methods-use-this */
+  renderVariants({ isLoadingVariants, tooManyVariants }) {
+    if (isLoadingVariants) {
+      return (
+        <TrackPageSection>
+          <StatusMessage>Loading variants...</StatusMessage>
+        </TrackPageSection>
+      )
+    }
+
+    if (tooManyVariants) {
+      return (
+        <TrackPageSection>
+          <StatusMessage>
+            This region has too many variants to display.
+            <br />
+            To view individual variants, select a smaller region.
+          </StatusMessage>
+        </TrackPageSection>
+      )
+    }
+
+    return (
+      <TrackPageSection>
+        <Settings />
+        <VariantTable tableConfig={tableConfig} />
+      </TrackPageSection>
+    )
+  }
+
+  render() {
+    return (
+      <RegionDataContainer
+        datasetId={this.props.datasetId}
+        fetchRegion={fetchRegion}
+        fetchVariants={fetchVariantsByRegion}
+        regionId={this.props.regionId}
+      >
+        {this.renderRegion}
+      </RegionDataContainer>
+    )
+  }
 }
 
-RegionPage.propTypes = {
-  errors: PropTypes.arrayOf(
-    PropTypes.shape({
-      message: PropTypes.string.isRequired,
-    })
-  ),
-  region: PropTypes.shape({
-    chrom: PropTypes.string.isRequired,
-    start: PropTypes.number.isRequired,
-    stop: PropTypes.number.isRequired,
-  }).isRequired,
-}
-
-RegionPage.defaultProps = {
-  errors: null,
-}
-
-export default RegionHoc(RegionPage, fetchRegion, 'gnomadCombinedVariants')
+export default RegionPage

--- a/projects/gnomad/src/StatusMessage.js
+++ b/projects/gnomad/src/StatusMessage.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+export default styled.div`
+  width: 50%;
+  padding: 15px;
+  margin: 1em auto;
+  font-size: 1.5em;
+  text-align: center;
+`

--- a/projects/gnomad/src/datasetLabels.js
+++ b/projects/gnomad/src/datasetLabels.js
@@ -1,0 +1,6 @@
+const datasetLabels = {
+  exac: 'ExAC',
+  gnomad_r2_0_2: 'gnomAD r2.0.2',
+}
+
+export default datasetLabels

--- a/projects/gnomad/src/routes.js
+++ b/projects/gnomad/src/routes.js
@@ -1,6 +1,8 @@
 import React from 'react'
-import styled from 'styled-components'
+import queryString from 'query-string'
 import { Route, Switch } from 'react-router-dom'
+import styled from 'styled-components'
+
 import { Help, HelpButton } from '@broad/help'
 
 import GenePage from './GenePage'
@@ -10,16 +12,19 @@ import TopBar from './TopBar'
 const Root = styled.div`
   display: flex;
   flex-direction: row;
-  font-family: Roboto, sans-serif;
-  font-size: 12px;
-  height: 100%;
   width: 100%;
-  background-color: #FAFAFA;;
+  height: 100%;
+  background-color: #fafafa;
+  font-family: Roboto, sans-serif;
+  font-size: 14px;
 `
 
 const MainPanel = styled.div`
   width: 100%;
 `
+
+const defaultDataset = 'gnomad_r2_0_2'
+
 const App = () => (
   <Root>
     <MainPanel>
@@ -29,19 +34,35 @@ const App = () => (
         <Route
           exact
           path="/gene/:gene/transcript/:transcriptId"
-          render={({ match }) => (
-            <GenePage geneName={match.params.gene} transcriptId={match.params.transcriptId} />
-          )}
+          render={({ location, match }) => {
+            const params = queryString.parse(location.search)
+            const datasetId = params.dataset || defaultDataset
+            return (
+              <GenePage
+                datasetId={datasetId}
+                geneIdOrName={match.params.gene}
+                transcriptId={match.params.transcriptId}
+              />
+            )
+          }}
         />
         <Route
           exact
           path="/gene/:gene"
-          render={({ match }) => <GenePage geneName={match.params.gene} />}
+          render={({ location, match }) => {
+            const params = queryString.parse(location.search)
+            const datasetId = params.dataset || defaultDataset
+            return <GenePage datasetId={datasetId} geneIdOrName={match.params.gene} />
+          }}
         />
         <Route
           exact
           path="/region/:regionId"
-          render={({ match }) => <RegionPage regionId={match.params.regionId} />}
+          render={({ location, match }) => {
+            const params = queryString.parse(location.search)
+            const datasetId = params.dataset || defaultDataset
+            return <RegionPage datasetId={datasetId} regionId={match.params.regionId} />
+          }}
         />
       </Switch>
       {/* <Route path="/variant/:variant" component={GenePage} /> */}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8858,6 +8858,14 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
+query-string@5:
+  version "5.1.1"
+  resolved "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"


### PR DESCRIPTION
Fetch variants only for the currently selected dataset. Currently, variants for both ExAC and gnomAD are always fetched but this becomes untenable as we add more subsets for gnomAD 2.1.

New Gene/RegionDataContainer components were added to avoid touching GeneHOC which is used by other projects.

Resolves #169