### PR TITLE
Add context-specific LC LoF / LOF Flag flags

### DIFF
--- a/projects/gnomad/data/export_exac_vcf_to_ht.py
+++ b/projects/gnomad/data/export_exac_vcf_to_ht.py
@@ -19,8 +19,9 @@ from hail_scripts.v02.utils.computed_fields import (
 
 p = argparse.ArgumentParser()
 p.add_argument(
-    "--output-url", help="URL to write Hail table to", default="gs://gnomad-browser/datasets/ExAC.r1.sites.vep.ht"
+    "--input-url", help="URL of ExAC sites VCF", default="gs://exac/170122_exacv1_bundle/ExAC.r1.sites.vep.vcf.gz"
 )
+p.add_argument("--output-url", help="URL to write Hail table to", required=True)
 p.add_argument("--subset", help="Filter variants to this chrom:start-end range")
 args = p.parse_args()
 
@@ -28,8 +29,7 @@ hl.init(log="/tmp/hail.log")
 
 print("\n=== Importing VCF ===")
 
-EXAC_VCF_URL = "gs://exac/170122_exacv1_bundle/ExAC.r1.sites.vep.vcf.gz"
-mt = hl.import_vcf(EXAC_VCF_URL, force_bgz=True, min_partitions=2000, skip_invalid_loci=True)
+mt = hl.import_vcf(args.input_url, force_bgz=True, min_partitions=2000, skip_invalid_loci=True)
 
 # Drop entry values
 mt = mt.drop("AD", "DP", "GQ", "GT", "MIN_DP", "PL", "SB")


### PR DESCRIPTION
Currently, the "LC LoF" and "LOF Flag" flags shown in the variant table are based on _all_ the variant's transcript consequences. This is appropriate for the region page. On the gene and transcript pages however, the flags should be based only on the transcript consequences within that gene/transcript (#369).

This change adds transcript level and gene level versions of these flags to each transcript consequence. The API can then return flags from the correct fields based on the context of the variant list (region, gene, or transcript).
https://github.com/macarthur-lab/gnomadjs/blob/9edc75223795c00886aab29ec904a49b61733e73/packages/api/src/schema/datasets/gnomad_r2_1/shapeGnomadVariantSummary.js#L76

The expressions for computing flags are in https://github.com/macarthur-lab/hail-elasticsearch-pipelines/blob/3153710de2d95205fcf5ca83e2082e2865b016c1/hail_scripts/v02/utils/computed_fields/flags.py

Also fixes the `original_alt_alleles` field in the ExAC loading pipeline (#385).