### PR TITLE
Kev/gnomad ingress ssl

### DIFF
--- a/packages/api/deploy/gnomad-api-controller.yaml
+++ b/packages/api/deploy/gnomad-api-controller.yaml
@@ -33,6 +33,12 @@ spec:
           value: 'THIS_STRING_IS_REPLACED_DURING_BUILD'
         ports:
         - containerPort: 80
+        readinessProbe:
+          httpGet:
+              path: /health
+              port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 20
         imagePullPolicy: Always
       nodeSelector:
         cloud.google.com/gke-nodepool: "redis"

--- a/projects/gnomad/deploy/gnomad-ingress.yaml
+++ b/projects/gnomad/deploy/gnomad-ingress.yaml
@@ -6,16 +6,28 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/ingress.global-static-ip-name: <IP NAME HERE>
+    ingress.gcp.kubernetes.io/pre-shared-cert: <CERT NAME HERE>
 spec:
-  tls:
-  - hosts: gnomad.broadinstitute.org
-    - gnomad
-    secretName: kev-cert-test
   rules:
   - host: gnomad.broadinstitute.org
     http:
       paths:
       - path: /
         backend:
-          serviceName: gnomad-p-serve
+          serviceName: gnomad-p-serve-nodeport
           servicePort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gnomad-p-serve-nodeport
+  labels:
+    state: serving
+spec:
+  type: NodePort
+  selector:
+    name: gnomad-p-serve
+  ports:
+  - port: 80
+    targetPort: 80

--- a/projects/gnomad/deploy/gnomad-ingress.yaml
+++ b/projects/gnomad/deploy/gnomad-ingress.yaml
@@ -6,8 +6,11 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: exac-gnomad-prod
-    ingress.gcp.kubernetes.io/pre-shared-cert: gnomad-kev-test
+    ingress.gcp.kubernetes.io/pre-shared-cert: gnomad-cert
 spec:
+  backend:
+    serviceName: gnomad-p-serve-nodeport
+    servicePort: 80
   rules:
   - host: gnomad.broadinstitute.org
     http:

--- a/projects/gnomad/deploy/gnomad-ingress.yaml
+++ b/projects/gnomad/deploy/gnomad-ingress.yaml
@@ -5,15 +5,14 @@ metadata:
   name: gnomad-ingress
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    kubernetes.io/ingress.global-static-ip-name: <IP NAME HERE>
-    ingress.gcp.kubernetes.io/pre-shared-cert: <CERT NAME HERE>
+    kubernetes.io/ingress.global-static-ip-name: exac-gnomad-prod
+    ingress.gcp.kubernetes.io/pre-shared-cert: gnomad-kev-test
 spec:
   rules:
   - host: gnomad.broadinstitute.org
     http:
       paths:
-      - path: /
+      - path:
         backend:
           serviceName: gnomad-p-serve-nodeport
           servicePort: 80

--- a/projects/gnomad/deploy/gnomad-ingress.yaml
+++ b/projects/gnomad/deploy/gnomad-ingress.yaml
@@ -15,6 +15,14 @@ spec:
   - host: gnomad.broadinstitute.org
     http:
       paths:
+      - path: /api
+        backend:
+          serviceName: gnomad-api-nodeport
+          servicePort: 80
+      - path: /api/*
+        backend:
+          serviceName: gnomad-api-nodeport
+          servicePort: 80
       - path:
         backend:
           serviceName: gnomad-p-serve-nodeport
@@ -30,6 +38,20 @@ spec:
   type: NodePort
   selector:
     name: gnomad-p-serve
+  ports:
+  - port: 80
+    targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gnomad-api-nodeport
+  labels:
+    state: serving
+spec:
+  type: NodePort
+  selector:
+    name: gnomad-api
   ports:
   - port: 80
     targetPort: 80

--- a/projects/gnomad/deploy/gnomad-ingress.yaml
+++ b/projects/gnomad/deploy/gnomad-ingress.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: gnomad-ingress
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  tls:
+  - hosts: gnomad.broadinstitute.org
+    - gnomad
+    secretName: kev-cert-test
+  rules:
+  - host: gnomad.broadinstitute.org
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: gnomad-p-serve
+          servicePort: 80


### PR DESCRIPTION
This is configuration for a load balancer that supports https for gnomad. Deployed https://gnomad.broadinstitute.org/.

