### PR TITLE
[gnomAD] Improve formatting of transcript consequence details

### DIFF
--- a/projects/gnomad/src/client/VariantPage/TranscriptConsequenceDetails.js
+++ b/projects/gnomad/src/client/VariantPage/TranscriptConsequenceDetails.js
@@ -1,7 +1,39 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import styled from 'styled-components'
 
 import { getCategoryFromConsequence } from '@broad/utilities'
+
+const AttributeName = styled.dt`
+  display: inline;
+
+  ::after {
+    content: ': ';
+  }
+`
+
+const AttributeValue = styled.dd`
+  display: inline;
+  margin: 0;
+`
+
+const AttributeList = styled.dl`
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+`
+
+const Attribute = ({ children, name }) => (
+  <div>
+    <AttributeName>{name}</AttributeName>
+    <AttributeValue>{children}</AttributeValue>
+  </div>
+)
+
+Attribute.propTypes = {
+  children: PropTypes.node.isRequired,
+  name: PropTypes.string.isRequired,
+}
 
 const colors = {
   red: '#FF583F',
@@ -20,12 +52,19 @@ const TranscriptConsequenceDetails = ({ consequence }) => {
     const siftColor = consequence.sift_prediction === 'tolerated' ? colors.green : colors.red
 
     return (
-      <span>
-        {consequence.hgvs}
-        <br />
-        Polyphen: <span style={{ color: polyphenColor }}>{consequence.polyphen_prediction}</span>;
-        SIFT: <span style={{ color: siftColor }}>{consequence.sift_prediction}</span>
-      </span>
+      <AttributeList>
+        <Attribute name="HGVSp">{consequence.hgvs}</Attribute>
+        {consequence.polyphen_prediction && (
+          <Attribute name="Polyphen">
+            <span style={{ color: polyphenColor }}>{consequence.polyphen_prediction}</span>
+          </Attribute>
+        )}
+        {consequence.sift_prediction && (
+          <Attribute name="SIFT">
+            <span style={{ color: siftColor }}>{consequence.sift_prediction}</span>
+          </Attribute>
+        )}
+      </AttributeList>
     )
   }
 
@@ -36,31 +75,32 @@ const TranscriptConsequenceDetails = ({ consequence }) => {
     (getCategoryFromConsequence(consequence.major_consequence) === 'lof' && !consequence.lof)
   ) {
     return (
-      <span>
-        {consequence.hgvs}
-        <br />
-        LoF:{' '}
-        <span style={{ color: colors.red }}>Low-confidence (Non-protein-coding transcript)</span>
-      </span>
+      <AttributeList>
+        <Attribute name="HGVSp">{consequence.hgvs}</Attribute>
+        <Attribute name="LoF">
+          <span style={{ color: colors.red }}>Low-confidence (Non-protein-coding transcript)</span>
+        </Attribute>
+      </AttributeList>
     )
   }
 
   if (consequence.lof) {
-    const lofColor = consequence.lof === 'HC' ? colors.green : colors.red
     return (
-      <span>
-        {consequence.hgvs}
-        <br />
-        LoF:{' '}
-        <span style={{ color: lofColor }}>
-          {consequence.lof === 'HC'
-            ? 'High-confidence'
-            : `Low-confidence (${consequence.lof_filter})`}
-        </span>
+      <AttributeList>
+        <Attribute name="HGVSp">{consequence.hgvs}</Attribute>
+        <Attribute name="LoF">
+          <span style={{ color: consequence.lof === 'HC' ? colors.green : colors.red }}>
+            {consequence.lof === 'HC'
+              ? 'High-confidence'
+              : `Low-confidence (${consequence.lof_filter})`}
+          </span>
+        </Attribute>
         {consequence.lof_flags && (
-          <span style={{ color: colors.yellow }}>Flag: {consequence.lof_flags}</span>
+          <Attribute name="Flag">
+            <span style={{ color: colors.yellow }}>{consequence.lof_flags}</span>
+          </Attribute>
         )}
-      </span>
+      </AttributeList>
     )
   }
 
@@ -80,6 +120,8 @@ TranscriptConsequenceDetails.propTypes = {
     lof_flags: PropTypes.string,
     lof_filter: PropTypes.string,
     major_consequence: PropTypes.string,
+    polyphen_prediction: PropTypes.string,
+    sift_prediction: PropTypes.string,
     transcript_id: PropTypes.string.isRequired,
   }).isRequired,
 }


### PR DESCRIPTION
Format details of LoF and missense transcript consequences so that each attribute appears on a different line.

---
LoF (15-79058622-GC-G)

Before:
<img width="712" alt="lof_before" src="https://user-images.githubusercontent.com/1156625/51868700-9a856280-231c-11e9-873e-4006f8bce446.png">

After:
<img width="703" alt="lof_after" src="https://user-images.githubusercontent.com/1156625/51868701-9a856280-231c-11e9-9190-fcc4d03aac4f.png">

---
Missense (1-55505545-C-T)

Before:
<img width="486" alt="missense_before" src="https://user-images.githubusercontent.com/1156625/51868702-9a856280-231c-11e9-997a-1381afa640a4.png">

After:
<img width="473" alt="missense_after" src="https://user-images.githubusercontent.com/1156625/51868703-9a856280-231c-11e9-8025-cbdc755156c4.png">

Resolves #354 