### PR TITLE
Set webpack-dev-server flags based on environment

### DIFF
--- a/projects/gnomad/config/webpack.config.client.js
+++ b/projects/gnomad/config/webpack.config.client.js
@@ -18,7 +18,6 @@ if (process.env.NODE_ENV === 'production' && !gaTrackingId) {
 const config = {
   devServer: {
     historyApiFallback: true,
-    host: '0.0.0.0',
     port: 8008,
     publicPath: '/',
     stats: 'errors-only',

--- a/projects/gnomad/start.sh
+++ b/projects/gnomad/start.sh
@@ -10,4 +10,9 @@ export PATH=$PATH:$PROJECT_DIR/node_modules/.bin
 export NODE_ENV="development"
 export GNOMAD_API_URL=${GNOMAD_API_URL:-"https://gnomad.broadinstitute.org/api"}
 
-webpack-dev-server --config=./config/webpack.config.client.js --hot --watch-poll
+WEBPACK_DEV_SERVER_ARGS=""
+if [ "$LOGNAME" = "vagrant" ]; then
+  WEBPACK_DEV_SERVER_ARGS="--host=0.0.0.0 --watch-poll"
+fi
+
+webpack-dev-server --config=./config/webpack.config.client.js --hot $WEBPACK_DEV_SERVER_ARGS


### PR DESCRIPTION
Running webpack-dev-server with `--host=0.0.0.0` and `--watch-poll` flags is necessary for development in a Vagrant machine. https://webpack.js.org/guides/development-vagrant/#running-the-server

However, `--watch-poll` can also cause high CPU usage, so it's preferable to only use that flag when necessary.