### PR TITLE
population ac_hom equal 0

### DIFF
--- a/projects/gnomad-api/src/schema/datasets/gnomad_r2_1/fetchGnomadVariantDetails.js
+++ b/projects/gnomad-api/src/schema/datasets/gnomad_r2_1/fetchGnomadVariantDetails.js
@@ -25,7 +25,7 @@ const formatPopulations = variantData => [
       id: `${popId.toUpperCase()}_${subPopId.toUpperCase()}`,
       ac: (variantData.AC_adj[popId] || {})[subPopId] || 0,
       an: (variantData.AN_adj[popId] || {})[subPopId] || 0,
-      ac_hemi: null,
+      ac_hemi: 0,
       ac_hom: (variantData.nhomalt_adj[popId] || {})[subPopId] || 0,
     })),
     {

--- a/projects/gnomad-api/src/schema/datasets/gnomad_r2_1/fetchGnomadVariantDetails.js
+++ b/projects/gnomad-api/src/schema/datasets/gnomad_r2_1/fetchGnomadVariantDetails.js
@@ -25,7 +25,7 @@ const formatPopulations = variantData => [
       id: `${popId.toUpperCase()}_${subPopId.toUpperCase()}`,
       ac: (variantData.AC_adj[popId] || {})[subPopId] || 0,
       an: (variantData.AN_adj[popId] || {})[subPopId] || 0,
-      ac_hemi: 0,
+      ac_hemi: null,
       ac_hom: (variantData.nhomalt_adj[popId] || {})[subPopId] || 0,
     })),
     {

--- a/projects/gnomad-api/src/schema/datasets/gnomad_r3/fetchGnomadV3VariantDetails.js
+++ b/projects/gnomad-api/src/schema/datasets/gnomad_r3/fetchGnomadV3VariantDetails.js
@@ -27,7 +27,7 @@ const formatPopulations = variantData => [
       ac: ((variantData.freq.adj.populations[popId] || {}).female || {}).AC || 0,
       an: ((variantData.freq.adj.populations[popId] || {}).female || {}).AN || 0,
       ac_hemi: 0,
-      ac_hom: ((variantData.freq.adj.populations[popId] || {}).female || {}).homozygote_count,
+      ac_hom: ((variantData.freq.adj.populations[popId] || {}).female || {}).homozygote_count || 0,
     },
     {
       id: `${popId.toUpperCase()}_MALE`,
@@ -36,7 +36,7 @@ const formatPopulations = variantData => [
       ac_hemi: variantData.nonpar
         ? ((variantData.freq.adj.populations[popId] || {}).male || {}).AC || 0
         : 0,
-      ac_hom: ((variantData.freq.adj.populations[popId] || {}).male || {}).homozygote_count,
+      ac_hom: ((variantData.freq.adj.populations[popId] || {}).male || {}).homozygote_count || 0,
     },
   ]),
   {


### PR DESCRIPTION
I had some issue when a population is absent from the dataset, the API return a null object then the front end could not find the population name of null object.

In the API, if we sett the population feilds to 0, then an object wuth the proper shape is sent, and the frontend can handle a population object properly.